### PR TITLE
Support Serde Serialize.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,14 @@ license = "BSD-3-Clause"
 log = "0.4"
 
 arc-swap = "^1.5"
-bytes = "1"
+bytes = { version = "1", features = [ "serde" ] }
 nom = "7.1"
-smallvec = { version = "1.8", features = [ "const_generics" ] }
+smallvec = { version = "1.8", features = [ "const_generics", "serde" ] }
+serde = { version = "1.0", features = [ "derive", "rc" ] }
 
 # use branch aspath-with-hops
-routecore = { version = "0.4.0-dev", features = ["bgp"], git = "https://github.com/NLnetLabs/routecore.git" }
-rotonda-store      = { version = "0.3.0-pre.2", git = "https://github.com/NLnetLabs/rotonda-store.git" }
+routecore = { version = "0.4.0-dev", features = ["bgp", "serde"], git = "https://github.com/NLnetLabs/routecore.git", branch = "more-serde-serialize" }
+rotonda-store = { version = "0.3.0-pre.2", git = "https://github.com/NLnetLabs/rotonda-store.git", branch = "more-serde-serialize" }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ smallvec = { version = "1.8", features = [ "const_generics", "serde" ] }
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 
 # use branch aspath-with-hops
-routecore = { version = "0.4.0-dev", features = ["bgp", "serde"], git = "https://github.com/NLnetLabs/routecore.git", branch = "more-serde-serialize" }
-rotonda-store = { version = "0.3.0-pre.2", git = "https://github.com/NLnetLabs/rotonda-store.git", branch = "more-serde-serialize" }
+routecore = { version = "0.4.0-dev", features = ["bgp", "serde"], git = "https://github.com/NLnetLabs/routecore.git" }
+rotonda-store = { version = "0.3.0-pre.2", git = "https://github.com/NLnetLabs/rotonda-store.git" }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -19,6 +19,7 @@ use nom::{
     combinator::map,
     IResult,
 };
+use serde::Serialize;
 use smallvec::SmallVec;
 
 use crate::compile::CompileError;
@@ -1675,7 +1676,7 @@ impl<'a> ByteStringLiteral {
 
 // AcceptReject ::= 'return'? ( 'accept' | 'reject' ) ';'
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AcceptReject {
     Accept,
     Reject,
@@ -2543,7 +2544,7 @@ impl PrefixLengthRange {
 
 //------------ ShortString ---------------------------------------------------
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub struct ShortString {
     bytes: SmallVec<[u8; 24]>,
 }

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -162,6 +162,7 @@ impl<S1: Into<TypeValue>, S2: ScalarValue + Into<TypeValue>> From<Option<S1>>
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct ReadOnlyScalarOption<T: ScalarValue + Into<TypeValue>> {
+    #[serde(flatten)]
     value: Option<TypeValue>,
     _pd: PhantomData<T>,
 }

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -1,6 +1,7 @@
 //------------ Route Status -------------------------------------------------
 
 use routecore::asn::LongSegmentError;
+use serde::Serialize;
 use std::marker::PhantomData;
 use std::ops::Index;
 
@@ -61,7 +62,7 @@ impl ScalarValue for RouteStatus {}
 
 // A attributes Change Set allows a user to create a set of changes to an
 // existing (raw) BGP Update message.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct AttrChangeSet {
     pub prefix: ReadOnlyScalarOption<Prefix>, // Read-only prefix typevalue, for referencing it.
     pub as_path: VectorOption<AsPath>,
@@ -91,7 +92,7 @@ pub struct AttrChangeSet {
 
 //------------ ScalarOption ------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ScalarOption<T: ScalarValue> {
     value: Option<TypeValue>,
     changed: bool,
@@ -159,7 +160,7 @@ impl<S1: Into<TypeValue>, S2: ScalarValue + Into<TypeValue>> From<Option<S1>>
 
 //------------ ReadOnlyScalarOption -----------------------------------------
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct ReadOnlyScalarOption<T: ScalarValue + Into<TypeValue>> {
     value: Option<TypeValue>,
     _pd: PhantomData<T>,
@@ -180,12 +181,12 @@ impl<T: ScalarValue + Into<TypeValue>> ReadOnlyScalarOption<T> {
 
 //------------ TodoOption ---------------------------------------------------
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize)]
 pub struct Todo;
 
 //------------ VectorOption -------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct VectorOption<V: VectorValue + Into<TypeValue>> {
     value: Option<TypeValue>,
     changed: bool,

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -93,9 +93,12 @@ pub struct AttrChangeSet {
 //------------ ScalarOption ------------------------------------------------
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct ScalarOption<T: ScalarValue> {
     value: Option<TypeValue>,
+    #[serde(skip)]
     changed: bool,
+    #[serde(skip)]
     _pd: PhantomData<T>,
 }
 
@@ -189,9 +192,12 @@ pub struct Todo;
 //------------ VectorOption -------------------------------------------------
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct VectorOption<V: VectorValue + Into<TypeValue>> {
     value: Option<TypeValue>,
+    #[serde(skip)]
     changed: bool,
+    #[serde(skip)]
     _pd: PhantomData<V>,
 }
 

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -161,8 +161,10 @@ impl<S1: Into<TypeValue>, S2: ScalarValue + Into<TypeValue>> From<Option<S1>>
 //------------ ReadOnlyScalarOption -----------------------------------------
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+#[serde(transparent)]
 pub struct ReadOnlyScalarOption<T: ScalarValue + Into<TypeValue>> {
     value: Option<TypeValue>,
+    #[serde(skip)]
     _pd: PhantomData<T>,
 }
 

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -68,6 +68,7 @@ pub struct AttrChangeSet {
     pub as_path: VectorOption<AsPath>,
     pub origin_type: ScalarOption<OriginType>,
     pub next_hop: ScalarOption<NextHop>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub multi_exit_discriminator: ScalarOption<MultiExitDisc>,
     pub local_pref: ScalarOption<LocalPref>,
     pub atomic_aggregate: ScalarOption<bool>,
@@ -104,6 +105,10 @@ pub struct ScalarOption<T: ScalarValue> {
 }
 
 impl<T: ScalarValue> ScalarOption<T> {
+    pub fn is_none(&self) -> bool {
+        self.value.is_none()
+    }
+
     pub fn into_opt(self) -> Option<TypeValue>
     where
         T: Copy,

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -95,6 +95,7 @@ pub struct AttrChangeSet {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct ScalarOption<T: ScalarValue> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<TypeValue>,
     #[serde(skip)]
     changed: bool,
@@ -166,6 +167,7 @@ impl<S1: Into<TypeValue>, S2: ScalarValue + Into<TypeValue>> From<Option<S1>>
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 #[serde(transparent)]
 pub struct ReadOnlyScalarOption<T: ScalarValue + Into<TypeValue>> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<TypeValue>,
     #[serde(skip)]
     _pd: PhantomData<T>,
@@ -194,6 +196,7 @@ pub struct Todo;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct VectorOption<V: VectorValue + Into<TypeValue>> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<TypeValue>,
     #[serde(skip)]
     changed: bool,

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -64,30 +64,51 @@ impl ScalarValue for RouteStatus {}
 // existing (raw) BGP Update message.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct AttrChangeSet {
+    #[serde(skip_serializing_if = "ReadOnlyScalarOption::is_none")]
     pub prefix: ReadOnlyScalarOption<Prefix>, // Read-only prefix typevalue, for referencing it.
+    #[serde(skip_serializing_if = "VectorOption::is_none")]
     pub as_path: VectorOption<AsPath>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub origin_type: ScalarOption<OriginType>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub next_hop: ScalarOption<NextHop>,
     #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub multi_exit_discriminator: ScalarOption<MultiExitDisc>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub local_pref: ScalarOption<LocalPref>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub atomic_aggregate: ScalarOption<bool>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub aggregator: ScalarOption<AtomicAggregator>,
+    #[serde(skip_serializing_if = "VectorOption::is_none")]
     pub communities: VectorOption<Vec<Community>>,
     // mp_reach_nlri: Vec<Prefix>,
     // mp_unreach_nlri: Vec<Prefix>,
+    #[serde(skip)]
     pub originator_id: Todo,
+    #[serde(skip)]
     pub cluster_list: Todo,
+    #[serde(skip)]
     pub extended_communities: Todo,
+    #[serde(skip_serializing_if = "VectorOption::is_none")]
     pub as4_path: VectorOption<AsPath>,
+    #[serde(skip)]
     pub as4_aggregator: Todo,
+    #[serde(skip)]
     pub connector: Todo, // Connector,
+    #[serde(skip)]
     pub as_path_limit: Todo,
+    #[serde(skip)]
     pub pmsi_tunnel: Todo, // PmsiTunnel,
+    #[serde(skip)]
     pub ipv6_extended_communities: Todo,
+    #[serde(skip)]
     pub large_communities: Todo,
+    #[serde(skip)]
     pub bgpsec_as_path: Todo,    // BgpsecAsPath,
+    #[serde(skip)]
     pub attr_set: Todo,          // AttrSet,
+    #[serde(skip)]
     pub rsrvd_development: Todo, // RsrvdDevelopment,
 }
 
@@ -186,6 +207,10 @@ impl<T: ScalarValue + Into<TypeValue>> ReadOnlyScalarOption<T> {
         }
     }
 
+    pub fn is_none(&self) -> bool {
+        self.value.is_none()
+    }
+
     pub fn as_ref(&self) -> Option<&TypeValue> {
         self.value.as_ref()
     }
@@ -216,6 +241,10 @@ impl<V: VectorValue + Into<TypeValue> + std::fmt::Debug> VectorOption<V> {
             changed: false,
             _pd: PhantomData,
         }
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.value.is_none()
     }
 
     pub fn into_opt(self) -> Option<TypeValue> {

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -162,7 +162,6 @@ impl<S1: Into<TypeValue>, S2: ScalarValue + Into<TypeValue>> From<Option<S1>>
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct ReadOnlyScalarOption<T: ScalarValue + Into<TypeValue>> {
-    #[serde(flatten)]
     value: Option<TypeValue>,
     _pd: PhantomData<T>,
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,7 @@
 // =========== RotoFilter trait ============================================
 
+use serde::Serialize;
+
 use crate::{
     ast::ShortString,
     compile::CompileError,
@@ -12,7 +14,7 @@ use crate::{
     vm::{StackValue, VmError},
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize)]
 pub enum Token {
     Variable(usize),
     Method(usize),

--- a/src/types/builtin/builtin_type_value.rs
+++ b/src/types/builtin/builtin_type_value.rs
@@ -5,6 +5,8 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use serde::Serialize;
+
 use crate::compile::CompileError;
 use crate::traits::{RotoType, Token};
 use crate::types::constant_enum::EnumVariant;
@@ -20,7 +22,7 @@ use super::{
     StringLiteral, U32, U8,
 };
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub enum BuiltinTypeValue {
     U32(U32),                       // scalar
     U8(U8),                         // scalar

--- a/src/types/builtin/builtin_type_value.rs
+++ b/src/types/builtin/builtin_type_value.rs
@@ -23,6 +23,7 @@ use super::{
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize)]
+#[serde(untagged)]
 pub enum BuiltinTypeValue {
     U32(U32),                       // scalar
     U8(U8),                         // scalar

--- a/src/types/builtin/primitives.rs
+++ b/src/types/builtin/primitives.rs
@@ -1978,7 +1978,7 @@ impl From<Asn> for Hop {
 
 //------------ OriginType type ----------------------------------------------
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct OriginType(pub(crate) routecore::bgp::types::OriginType);
 
 impl OriginType {
@@ -2061,7 +2061,7 @@ impl Display for OriginType {
 
 //------------ NextHop type -------------------------------------------------
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct NextHop(pub(crate) routecore::bgp::types::NextHop);
 
 impl RotoType for NextHop {
@@ -2138,7 +2138,7 @@ impl Display for NextHop {
 
 //------------ Multi Exit Discriminator type --------------------------------
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct MultiExitDisc(pub(crate) routecore::bgp::types::MultiExitDisc);
 
 impl RotoType for MultiExitDisc {

--- a/src/types/builtin/primitives.rs
+++ b/src/types/builtin/primitives.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use log::trace;
 use routecore::asn::LongSegmentError;
+use serde::Serialize;
 
 use crate::attr_change_set::VectorValue;
 use crate::compile::CompileError;
@@ -16,7 +17,7 @@ use super::builtin_type_value::BuiltinTypeValue;
 
 // ----------- A simple u32 type --------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct U32(pub(crate) u32);
 
 impl U32 {
@@ -146,7 +147,7 @@ impl From<U32Token> for usize {
 
 // ----------- A simple u8 type ---------------------------------------------
 
-#[derive(Debug, Eq, Copy, Clone)]
+#[derive(Debug, Eq, Copy, Clone, Serialize)]
 pub struct U8(pub(crate) u8);
 
 impl U8 {
@@ -285,7 +286,7 @@ impl From<U8Token> for usize {
 
 // ----------- Boolean type -------------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct Boolean(pub(crate) bool);
 impl Boolean {
     pub fn new(val: bool) -> Self {
@@ -411,7 +412,7 @@ impl From<BooleanToken> for usize {
 
 //------------ StringLiteral type -------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub struct StringLiteral(pub(crate) String);
 impl StringLiteral {
     pub fn new(val: String) -> Self {
@@ -552,7 +553,7 @@ impl From<StringLiteralToken> for usize {
 
 //------------ IntegerLiteral type ------------------------------------------
 
-#[derive(Debug, Eq, Ord, PartialOrd, Copy, Clone)]
+#[derive(Debug, Eq, Ord, PartialOrd, Copy, Clone, Serialize)]
 pub struct IntegerLiteral(pub(crate) i64);
 impl IntegerLiteral {
     pub fn new(val: i64) -> Self {
@@ -706,7 +707,7 @@ impl From<IntegerLiteralToken> for usize {
 
 //------------ HexLiteral type ----------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct HexLiteral(pub(crate) u64);
 impl HexLiteral {
     pub fn new(val: u64) -> Self {
@@ -837,7 +838,7 @@ impl From<HexLiteralToken> for usize {
 
 // ----------- Prefix type --------------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct Prefix(pub(crate) routecore::addr::Prefix);
 
 impl Prefix {
@@ -1040,7 +1041,7 @@ impl From<PrefixToken> for usize {
 
 //------------ PrefixLengthLiteral type -------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct PrefixLength(pub(crate) u8);
 
 impl PrefixLength {
@@ -1185,7 +1186,7 @@ impl From<PrefixLength> for u8 {
 
 // ----------- Community ----------------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct Community(pub(crate) routecore::bgp::communities::Community);
 
 impl Community {
@@ -1378,7 +1379,7 @@ pub enum MatchType {
 
 // ----------- IpAddress type -----------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct IpAddress(pub(crate) std::net::IpAddr);
 
 impl IpAddress {
@@ -1495,7 +1496,7 @@ impl From<IpAddressToken> for usize {
 
 // ----------- Asn type -----------------------------------------------------
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize)]
 pub struct Asn(pub(crate) routecore::asn::Asn);
 
 impl Asn {
@@ -1642,7 +1643,7 @@ impl From<AsnToken> for usize {
 
 type RoutecoreHop = routecore::bgp::aspath::Hop<Vec<u8>>;
 
-#[derive(Debug, Eq, PartialEq, Clone, Default)]
+#[derive(Debug, Eq, PartialEq, Clone, Default, Serialize)]
 pub struct AsPath(pub(crate) routecore::bgp::aspath::HopPath);
 
 impl AsPath {
@@ -1912,7 +1913,7 @@ impl From<Vec<Hop>> for AsPath {
 // A read-only type that contains an ASN or a more complex segment of a AS
 // PATH, e.g. an AS_SET.
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct Hop(pub(crate) routecore::bgp::aspath::Hop<Vec<u8>>);
 
 impl RotoType for Hop {
@@ -1977,7 +1978,7 @@ impl From<Asn> for Hop {
 
 //------------ OriginType type ----------------------------------------------
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct OriginType(pub(crate) routecore::bgp::types::OriginType);
 
 impl OriginType {
@@ -2060,7 +2061,7 @@ impl Display for OriginType {
 
 //------------ NextHop type -------------------------------------------------
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct NextHop(pub(crate) routecore::bgp::types::NextHop);
 
 impl RotoType for NextHop {
@@ -2137,7 +2138,7 @@ impl Display for NextHop {
 
 //------------ Multi Exit Discriminator type --------------------------------
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct MultiExitDisc(pub(crate) routecore::bgp::types::MultiExitDisc);
 
 impl RotoType for MultiExitDisc {
@@ -2309,7 +2310,7 @@ impl From<UnknownToken> for usize {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize)]
 pub struct LocalPref(pub(crate) routecore::bgp::types::LocalPref);
 
 impl RotoType for LocalPref {
@@ -2422,7 +2423,7 @@ impl From<LocalPrefToken> for usize {
 
 //------------ Aggregator type ----------------------------------------------
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize)]
 pub struct AtomicAggregator(
     pub(crate) routecore::bgp::message::update::Aggregator,
 );
@@ -2512,7 +2513,7 @@ impl std::fmt::Display for AtomicAggregator {
 // the logic in `rib-units` to decide whether routes should be send to its
 // output and to be able output this information to API clients, without
 // having to go back to the units that keep the per-peer session state.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Serialize)]
 pub enum RouteStatus {
     // Between start and EOR on a BGP peer-session
     InConvergence,

--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -59,7 +59,7 @@ use crate::attr_change_set::{
 // a RIB (that is the RawRouteDelta down below), but the type that is used
 // serialize the data into on export and transport.
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub struct MaterializedRoute {
     pub route: AttrChangeSet,
     pub status: RouteStatus,
@@ -92,6 +92,7 @@ impl From<RawRouteWithDeltas> for MaterializedRoute {
 // original attributes from the raw message, their modifications and the
 // newly set attributes.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(into = "MaterializedRoute")]
 pub struct RawRouteWithDeltas {
     pub prefix: Prefix,
     // Arc'ed BGP message

--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -12,9 +12,8 @@
 //                 └─────────────┘  status
 
 use log::trace;
-use routecore::bgp::{
-    message::SessionConfig,
-};
+use routecore::bgp::message::SessionConfig;
+use serde::Serialize;
 use std::sync::Arc;
 
 /// Lamport Timestamp. Used to order messages between units/systems.
@@ -92,7 +91,7 @@ impl From<RawRouteWithDeltas> for MaterializedRoute {
 // was stored in the RawRouteWithDeltas instance. So it reflects both the
 // original attributes from the raw message, their modifications and the
 // newly set attributes.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct RawRouteWithDeltas {
     pub prefix: Prefix,
     // Arc'ed BGP message
@@ -414,7 +413,7 @@ impl RawRouteWithDeltas {
 //
 // The list of deltas describes the changes that were made by one Rotonda
 // unit along the way.
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize)]
 struct AttributeDeltaList {
     deltas: Vec<AttributeDelta>,
     // The delta that was handed out the most recently. This is the only
@@ -465,7 +464,7 @@ impl AttributeDeltaList {
 
 // A set of attribute changes that were atomically created by a Rotonda
 // unit in one go (with one logical timestamp).
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct AttributeDelta {
     delta_id: (RotondaId, LogicalTime),
     delta_index: usize,
@@ -486,7 +485,7 @@ impl AttributeDelta {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 struct RouteStatusDelta {
     delta_id: (RotondaId, LogicalTime),
     status: TypeValue,
@@ -501,7 +500,7 @@ impl RouteStatusDelta {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 struct RouteStatusDeltaList(Vec<RouteStatusDelta>);
 
 impl RouteStatusDeltaList {
@@ -523,7 +522,7 @@ impl RouteStatusDeltaList {
 // The `attr_cache` AttributeList allows readers to get a reference to a path
 // attribute. This avoids having to clone from the AttributeLists in the
 // iterator over the latest attributes.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BgpUpdateMessage {
     message_id: (RotondaId, LogicalTime),
     // nlris: TypeValue,
@@ -1019,13 +1018,13 @@ impl From<RouteStatusToken> for usize {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize)]
 pub struct RotondaId(pub usize);
 
 
 //------------ Modification & Creation of new Updates -----------------------
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UpdateMessage(
     pub routecore::bgp::message::UpdateMessage<bytes::Bytes>,
 );

--- a/src/types/collections.rs
+++ b/src/types/collections.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use smallvec::SmallVec;
 
 use crate::ast::{
@@ -22,7 +23,7 @@ use super::typevalue::TypeValue;
 // collections (that only contain primitive types). The latter do not need to
 // be boxed, while the former do.
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub enum ElementTypeValue {
     Primitive(TypeValue),
     Nested(Box<TypeValue>),
@@ -174,7 +175,7 @@ impl From<ValueExpr> for ElementTypeValue {
 
 //------------ List type ----------------------------------------------------
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct List(pub(crate) Vec<ElementTypeValue>);
 
 impl List {
@@ -533,7 +534,7 @@ impl From<ListToken> for usize {
 
 //---------------- Record type ----------------------------------------------
 
-#[derive(Debug, PartialEq, Eq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Serialize)]
 pub struct Record(pub(crate) Vec<(ShortString, ElementTypeValue)>);
 
 impl<'a> Record {

--- a/src/types/constant_enum.rs
+++ b/src/types/constant_enum.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use log::trace;
 use routecore::bgp::communities::Wellknown;
 use routecore::bgp::types::{AFI, SAFI};
+use serde::Serialize;
 
 use crate::{
     ast::ShortString,
@@ -18,7 +19,7 @@ use super::{
 
 //------------ EnumVariant --------------------------------------------------
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct EnumVariant<T> {
     pub(crate) enum_name: ShortString,
     pub(crate) value: T,
@@ -127,7 +128,7 @@ impl From<EnumVariant<u32>> for BuiltinTypeValue {
 
 //------------ Enum ---------------------------------------------------------
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct Enum {
     ty: TypeDef,
     token: Token,

--- a/src/types/outputs.rs
+++ b/src/types/outputs.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use crate::{
     ast::ShortString,
     compile::CompileError,
@@ -90,7 +92,7 @@ impl From<OutputStreamToken> for usize {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct OutputStreamMessage {
     pub(crate) name: ShortString,
     pub(crate) topic: String,

--- a/src/types/typedef.rs
+++ b/src/types/typedef.rs
@@ -3,6 +3,7 @@
 // These are all the types the user can create. This enum is used to create
 // `user defined` types.
 use log::trace;
+use serde::Serialize;
 
 use crate::compile::CompileError;
 use crate::traits::Token;
@@ -29,7 +30,7 @@ use super::{
     builtin::BuiltinTypeValue, collections::List, typevalue::TypeValue,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize)]
 pub enum TypeDef {
     // Data Sources, the data field in the enum represents the contained
     // type.

--- a/src/types/typevalue.rs
+++ b/src/types/typevalue.rs
@@ -33,6 +33,7 @@ use super::{
 /// variants can hold multiple values recursively, e.g. a List of Records.
 
 #[derive(Debug, Eq, Default, Clone, Serialize)]
+#[serde(untagged)]
 pub enum TypeValue {
     // All the built-in scalars and vectors
     Builtin(BuiltinTypeValue),

--- a/src/types/typevalue.rs
+++ b/src/types/typevalue.rs
@@ -2,6 +2,7 @@ use std::{cmp::Ordering, fmt::Display, sync::Arc};
 
 use log::trace;
 use primitives::Hop;
+use serde::Serialize;
 use smallvec::SmallVec;
 
 //============ TypeValue ====================================================
@@ -31,7 +32,7 @@ use super::{
 /// holds both the type-level information and the value. The collection
 /// variants can hold multiple values recursively, e.g. a List of Records.
 
-#[derive(Debug, Eq, Default, Clone)]
+#[derive(Debug, Eq, Default, Clone, Serialize)]
 pub enum TypeValue {
     // All the built-in scalars and vectors
     Builtin(BuiltinTypeValue),


### PR DESCRIPTION
This is an opinionated PR that performs lossy serialization targeting end users or systems consuming the data structures serialized as, e.g. JSON, i.e. it is not attempting to serialize the data structures faithfully but rather to include only those fields which have value to an end consumer rather than an internal actor.

As such this PR:
  - Hides internal details (e.g. `changed` and `_pd`) using Serde derive  attributes`skip` and `transparent`.
  - Hides `None` field values via Serde derive attribute `skip_serializing_if`.
  - Flattens the structure (e.g. don't serialize enum variants as being contained in a container by the name of the enum) via Serde derive attribute `untagged`.
- Serializes `RawRouteWithDeltas` as type  `MaterializedRoute` via Serde derive attribute `into` - because an end consumer of a `TypeValue` stored in a RIB (for example) will only be interested in the effect of accumulating the associated deltas, not in the deltas themselves.