### PR TITLE
Require RawRouteWithDeltas to have a RouteStatus.

### DIFF
--- a/examples/asn_in_out.rs
+++ b/examples/asn_in_out.rs
@@ -1,6 +1,6 @@
 use roto::compile::Compiler;
 
-use roto::types::builtin::{RawRouteWithDeltas, RotondaId, UpdateMessage, Prefix, Asn};
+use roto::types::builtin::{RawRouteWithDeltas, RotondaId, UpdateMessage, Prefix, Asn, RouteStatus};
 use roto::types::collections::Record;
 use roto::types::typedef::TypeDef;
 use roto::vm;
@@ -44,6 +44,7 @@ fn test_data(
         (RotondaId(0), 0),
         _prefixes[0],
         _update,
+        RouteStatus::InConvergence,
     );
 
 

--- a/examples/route.rs
+++ b/examples/route.rs
@@ -1,6 +1,6 @@
 use roto::compile::Compiler;
 
-use roto::types::builtin::{RawRouteWithDeltas, RotondaId, UpdateMessage, Prefix};
+use roto::types::builtin::{RawRouteWithDeltas, RotondaId, UpdateMessage, Prefix, RouteStatus};
 use roto::types::collections::Record;
 use roto::types::typevalue::TypeValue;
 use roto::vm;
@@ -44,6 +44,7 @@ fn test_data(
         msg_id,
         prefixes[0],
         update,
+        RouteStatus::InConvergence,
     );
 
     // Create the VM

--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -108,6 +108,7 @@ impl RawRouteWithDeltas {
         delta_id: (RotondaId, LogicalTime),
         prefix: Prefix,
         raw_message: UpdateMessage,
+        route_status: RouteStatus,
     ) -> Self {
         let raw_message = BgpUpdateMessage::new(delta_id, raw_message);
         let mut attribute_deltas = AttributeDeltaList::new();
@@ -125,7 +126,7 @@ impl RawRouteWithDeltas {
             raw_message: Arc::new(raw_message),
             attribute_deltas,
             status_deltas: RouteStatusDeltaList(vec![RouteStatusDelta::new(
-                delta_id,
+                delta_id, route_status.into(),
             )]),
         }
     }
@@ -134,13 +135,14 @@ impl RawRouteWithDeltas {
         delta_id: (RotondaId, LogicalTime),
         prefix: Prefix,
         raw_message: &Arc<BgpUpdateMessage>,
+        route_status: RouteStatus,
     ) -> Self {
         Self {
             prefix,
             raw_message: Arc::clone(raw_message),
             attribute_deltas: AttributeDeltaList::new(),
             status_deltas: RouteStatusDeltaList(vec![RouteStatusDelta::new(
-                delta_id,
+                delta_id, route_status.into(),
             )]),
         }
     }
@@ -493,10 +495,10 @@ struct RouteStatusDelta {
 }
 
 impl RouteStatusDelta {
-    pub fn new(delta_id: (RotondaId, LogicalTime)) -> Self {
+    pub fn new(delta_id: (RotondaId, LogicalTime), status: TypeValue) -> Self {
         Self {
             delta_id,
-            status: TypeValue::UnInit,
+            status,
         }
     }
 }

--- a/src/types/builtin/tests.rs
+++ b/src/types/builtin/tests.rs
@@ -7,7 +7,7 @@ mod route {
 
     use crate::{
         types::builtin::{
-            Asn, Prefix, RawRouteWithDeltas, RotondaId, UpdateMessage,
+            Asn, Prefix, RawRouteWithDeltas, RotondaId, UpdateMessage, RouteStatus,
         },
         vm::VmError,
     };
@@ -49,6 +49,7 @@ mod route {
             msg_id,
             prefixes[0],
             update,
+            RouteStatus::InConvergence,
         ));
 
         for prefix in &prefixes[1..] {
@@ -56,6 +57,7 @@ mod route {
                 msg_id,
                 *prefix,
                 &roto_msgs[0].raw_message,
+                RouteStatus::InConvergence,
             ))
         }
 
@@ -156,6 +158,7 @@ mod route {
             msg_id,
             prefixes[0],
             update,
+            RouteStatus::InConvergence,
         ));
 
         for prefix in &prefixes[1..] {
@@ -163,6 +166,7 @@ mod route {
                 msg_id,
                 *prefix,
                 &roto_msgs[0].raw_message,
+                RouteStatus::InConvergence,
             ))
         }
 


### PR DESCRIPTION
This change makes it easier to set the status of a route on creation and ensures they always have a status, e.g. in convergence, withdrawn, etc.