### PR TITLE
Add route withdrawal related functionality

### DIFF
--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -57,6 +57,7 @@ impl ScalarValue for Community {}
 impl ScalarValue for Prefix {}
 impl ScalarValue for RouteStatus {}
 impl ScalarValue for IpAddress {}
+impl ScalarValue for Asn {}
 // impl ScalarValue for (u8, u32) {}
 
 //------------ Attributes Change Set ----------------------------------------
@@ -85,6 +86,8 @@ pub struct AttrChangeSet {
     pub communities: VectorOption<Vec<Community>>,
     #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub peer_ip: ScalarOption<IpAddress>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
+    pub peer_asn: ScalarOption<Asn>,
     // mp_reach_nlri: Vec<Prefix>,
     // mp_unreach_nlri: Vec<Prefix>,
     #[serde(skip)]

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -7,7 +7,7 @@ use std::ops::Index;
 
 use crate::types::builtin::{
     AsPath, Asn, AtomicAggregator, BuiltinTypeValue, Community, LocalPref,
-    MultiExitDisc, NextHop, OriginType, Prefix, RouteStatus,
+    MultiExitDisc, NextHop, OriginType, Prefix, RouteStatus, IpAddress,
 };
 use crate::types::collections::ElementTypeValue;
 use crate::types::typevalue::TypeValue;
@@ -56,6 +56,7 @@ impl ScalarValue for AtomicAggregator {}
 impl ScalarValue for Community {}
 impl ScalarValue for Prefix {}
 impl ScalarValue for RouteStatus {}
+impl ScalarValue for IpAddress {}
 // impl ScalarValue for (u8, u32) {}
 
 //------------ Attributes Change Set ----------------------------------------
@@ -82,6 +83,8 @@ pub struct AttrChangeSet {
     pub aggregator: ScalarOption<AtomicAggregator>,
     #[serde(skip_serializing_if = "VectorOption::is_none")]
     pub communities: VectorOption<Vec<Community>>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
+    pub peer_ip: ScalarOption<IpAddress>,
     // mp_reach_nlri: Vec<Prefix>,
     // mp_unreach_nlri: Vec<Prefix>,
     #[serde(skip)]

--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -168,6 +168,11 @@ impl RawRouteWithDeltas {
         self.peer_ip.map(|ip| ip.0)
     }
 
+    pub fn update_status(&mut self, delta_id: (RotondaId, LogicalTime), new_status: RouteStatus) {
+        let delta = RouteStatusDelta::new(delta_id, new_status.into());
+        self.status_deltas.0.push(delta);
+    }
+
     // Get a clone of the latest delta, or of the original attributes from
     // the raw message, if no delta has been added (yet).
     fn clone_latest_attrs(&self) -> AttrChangeSet {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -119,7 +119,9 @@ pub struct LinearMemory([TypeValue; 512]);
 
 impl LinearMemory {
     pub fn uninit() -> Self {
-        LinearMemory(std::array::from_fn(|_| TypeValue::UnInit))
+        // LinearMemory(std::array::from_fn(|_| TypeValue::UnInit))
+        const V: TypeValue = TypeValue::UnInit;
+        LinearMemory([V; 512])
     }
 
     pub fn get_mem_pos(&self, index: usize) -> Option<&TypeValue> {


### PR DESCRIPTION
To withdraw a route we need to match it by originating peer as well as prefix and AS path, and we need to set its stays to withdrawn.

This PR adds optional support for setting the peer IP address and peer ASN. Why these fields and why optional? And it adds support for changing the route status (e.g. to withdrawn).

Optional because I did not think it wise for example to support the notion of internally originated routes by setting our own IP address as the peer IP, but rather to be explicit that there is no IP address from which the route was received. Also, which IP address is our own? What if we have multiple? Do we even know that at the point it needs to be set? Do we know it at the point it needs to be detected?

Peer IP address and/or ASN: perhaps these should both be set together, but that was more work to implement the required roto trait impls, e.g. would it need a new “primitive” type?

Peer IP address: routes are received from peers who have an IP address, so this much is I think not controversial.

Peer ASN: its unclear if ASN (or other fields?) should also be used to identify a peer. @DRiKE made the argument that the RFCs don’t seem to exclude the notion of multiple peers from the same IP address, and that for example if transitioning from one ASN to another a router may be configured with separate BGP sessions with separate ASNs but the same router IP address, but dropping routes from one if its session goes down should not cause the routes from the other to also be dropped.

This is also the same tuple we used previously as a peer “ID”.

@DRiKE also suggested confirming with ram router operators what they consider the peer ID to be. (note that we are NOT talking about BGP Identifier here as that seems from the RFCs to be shared by all peers from a single router, so does not help to uniquely identify a peer on its own, though could maybe be part of an ID tuple?)
