### PR TITLE
Faster route status updates

### DIFF
--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -587,7 +587,6 @@ impl RouteStatusDeltaList {
     }
 
     pub fn current_as_ref(&self) -> Option<&TypeValue> {
-        // self.0.iter().last().map(|s| &s.status)
         None
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -226,6 +226,8 @@ impl LinearMemory {
                         route.get_value_ref_for_field(field_index[0])
                     {
                         Some(StackValue::Ref(v))
+                    } else if let Some(v) = route.get_field_by_index(field_index[0]) {
+                        Some(StackValue::Owned(v))
                     } else {
                         Some(StackValue::Owned(TypeValue::Unknown))
                     }


### PR DESCRIPTION
Flamegraph analysis pointed to a surprising amount of time spent relatively in setting the status of a route when withdrawn, partly in Vec creation and partly in TypeValue::drop().

As route status changes probably won't happen a lot use a SmallVec<[RouteStatus; 2]> instead of a Vec to avoid allocation cost.

And as we don't accept TypeValue in but only RouteStatus, actually store RouteStatus.