### PR TITLE
To be, or not to be (a changeset)?

### DIFF
--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -389,10 +389,8 @@ impl RawRouteWithDeltas {
         &self,
         field_token: usize,
     ) -> Option<TypeValue> {
-        let current_set = self.attribute_deltas.get_latest_change_set()?;
-
         match field_token.into() {
-            RouteToken::AsPath => current_set.as_path.clone().into_opt(),
+            RouteToken::AsPath => self.raw_message.raw_message.0.aspath().map(|p| p.to_hop_path()).map(TypeValue::from),
             RouteToken::OriginType => {
                 self.raw_message.raw_message.0.origin().map(TypeValue::from)
             }


### PR DESCRIPTION
There isn't a changeset yet when `Typedef::hash_key_values()` is invoked because `new_with_message_ref()` was called instead of `new_with_message()`, but we (a) want to invoke`TypeDef::hash_key_values()` which prior to this PR requires a changeset (and for only one route property and uses BGP UPDATE values directly for the rest), and (b) don’t want to create a changeset (which is costly) for every message we store just to work out the hashcode from a few key fields.

This PR fixes the one lookup that needs the changeset so that the changeset is not needed, and this also removes the ? that causes the fn to terminate early which terminates the hash code generation call tree early (but just resulting in a zero hashcode instead of an error).

However, it may be that the fn needs to support both calling without having a changeset, and when there is one… this PR does not address that case.

Also note that this PR targets the `more-serialization` branch as that’s where I happened to be working when I hit this issue.