### PR TITLE
MergeUpdate UserData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ smallvec = { version = "1.8", features = [ "const_generics", "serde" ] }
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 
 routecore = { version = "0.4.0-dev", features = ["bgp", "serde"], git = "https://github.com/NLnetLabs/routecore.git" }
-rotonda-store = { version = "0.3.0-pre.2", git = "https://github.com/NLnetLabs/rotonda-store.git" }
+rotonda-store = { version = "0.3.0-pre.2", git = "https://github.com/NLnetLabs/rotonda-store.git", branch = "mergeupdate-userdata" }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -14,6 +14,8 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserData = ();
+
     fn merge_update(
         &mut self,
         update_record: RibValue,
@@ -25,13 +27,13 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<Self, Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {
         let mut new_meta = update_meta.0.clone();
         new_meta.push(self.0[0].clone());
-        Ok(RibValue(new_meta))
+        Ok((RibValue(new_meta), ()))
     }
 }
 

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -14,11 +14,13 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserDataIn = ();
     type UserDataOut = ();
 
     fn merge_update(
         &mut self,
         update_record: RibValue,
+        _: Self::UserDataIn,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -27,6 +29,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
+        _: &Self::UserDataIn,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -14,7 +14,7 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
-    type UserData = ();
+    type UserDataOut = ();
 
     fn merge_update(
         &mut self,
@@ -27,7 +27,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -20,7 +20,7 @@ impl MergeUpdate for RibValue {
     fn merge_update(
         &mut self,
         update_record: RibValue,
-        _: Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -29,7 +29,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-        _: &Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -21,7 +21,7 @@ impl MergeUpdate for RibValue {
     fn merge_update(
         &mut self,
         update_record: RibValue,
-        _: Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -30,7 +30,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-        _: &Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -15,6 +15,8 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserData = ();
+
     fn merge_update(
         &mut self,
         update_record: RibValue,
@@ -26,13 +28,13 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<Self, Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {
         let mut new_meta = update_meta.0.clone();
         new_meta.push(self.0[0].clone());
-        Ok(RibValue(new_meta))
+        Ok((RibValue(new_meta), ()))
     }
 }
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -15,11 +15,13 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserDataIn = ();
     type UserDataOut = ();
 
     fn merge_update(
         &mut self,
         update_record: RibValue,
+        _: Self::UserDataIn,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -28,6 +30,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
+        _: &Self::UserDataIn,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -15,7 +15,7 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
-    type UserData = ();
+    type UserDataOut = ();
 
     fn merge_update(
         &mut self,
@@ -28,7 +28,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {

--- a/tests/eq_conversions.rs
+++ b/tests/eq_conversions.rs
@@ -14,6 +14,8 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserData = ();
+
     fn merge_update(
         &mut self,
         update_record: RibValue,
@@ -25,13 +27,13 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<Self, Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {
         let mut new_meta = update_meta.0.clone();
         new_meta.push(self.0[0].clone());
-        Ok(RibValue(new_meta))
+        Ok((RibValue(new_meta), ()))
     }
 }
 

--- a/tests/eq_conversions.rs
+++ b/tests/eq_conversions.rs
@@ -14,11 +14,13 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserDataIn = ();
     type UserDataOut = ();
 
     fn merge_update(
         &mut self,
         update_record: RibValue,
+        _: Self::UserDataIn,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -27,6 +29,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
+        _: &Self::UserDataIn,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/eq_conversions.rs
+++ b/tests/eq_conversions.rs
@@ -14,7 +14,7 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
-    type UserData = ();
+    type UserDataOut = ();
 
     fn merge_update(
         &mut self,
@@ -27,7 +27,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {

--- a/tests/eq_conversions.rs
+++ b/tests/eq_conversions.rs
@@ -20,7 +20,7 @@ impl MergeUpdate for RibValue {
     fn merge_update(
         &mut self,
         update_record: RibValue,
-        _: Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -29,7 +29,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-        _: &Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -21,7 +21,7 @@ impl MergeUpdate for RibValue {
     fn merge_update(
         &mut self,
         update_record: RibValue,
-        _: Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -30,7 +30,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-        _: &Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -15,6 +15,8 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserData = ();
+
     fn merge_update(
         &mut self,
         update_record: RibValue,
@@ -26,13 +28,13 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<Self, Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {
         let mut new_meta = update_meta.0.clone();
         new_meta.push(self.0[0].clone());
-        Ok(RibValue(new_meta))
+        Ok((RibValue(new_meta), ()))
     }
 }
 

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -15,11 +15,13 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserDataIn = ();
     type UserDataOut = ();
 
     fn merge_update(
         &mut self,
         update_record: RibValue,
+        _: Self::UserDataIn,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -28,6 +30,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
+        _: &Self::UserDataIn,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/lists.rs
+++ b/tests/lists.rs
@@ -15,7 +15,7 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
-    type UserData = ();
+    type UserDataOut = ();
 
     fn merge_update(
         &mut self,
@@ -28,7 +28,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {

--- a/tests/records.rs
+++ b/tests/records.rs
@@ -21,7 +21,7 @@ impl MergeUpdate for RibValue {
     fn merge_update(
         &mut self,
         update_record: RibValue,
-        _: Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -30,7 +30,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-        _: &Self::UserDataIn,
+        _: Option<&Self::UserDataIn>,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/records.rs
+++ b/tests/records.rs
@@ -15,6 +15,8 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserData = ();
+
     fn merge_update(
         &mut self,
         update_record: RibValue,
@@ -26,13 +28,13 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<Self, Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {
         let mut new_meta = update_meta.0.clone();
         new_meta.push(self.0[0].clone());
-        Ok(RibValue(new_meta))
+        Ok((RibValue(new_meta), ()))
     }
 }
 

--- a/tests/records.rs
+++ b/tests/records.rs
@@ -15,11 +15,13 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
+    type UserDataIn = ();
     type UserDataOut = ();
 
     fn merge_update(
         &mut self,
         update_record: RibValue,
+        _: Self::UserDataIn,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.0 = update_record.0;
         Ok(())
@@ -28,6 +30,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
+        _: &Self::UserDataIn,
     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,

--- a/tests/records.rs
+++ b/tests/records.rs
@@ -15,7 +15,7 @@ mod common;
 struct RibValue(Vec<TypeValue>);
 
 impl MergeUpdate for RibValue {
-    type UserData = ();
+    type UserDataOut = ();
 
     fn merge_update(
         &mut self,
@@ -28,7 +28,7 @@ impl MergeUpdate for RibValue {
     fn clone_merge_update(
         &self,
         update_meta: &Self,
-    ) -> Result<(Self, Self::UserData), Box<dyn std::error::Error>>
+    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
     where
         Self: std::marker::Sized,
     {


### PR DESCRIPTION
Changes caused by https://github.com/NLnetLabs/rotonda-store/pull/30.

Note: This PR modifies `Cargo.toml` to use a Git dependency, but instead the `rotonda-store` changes should perhaps be pushed to crates.io. 