### PR TITLE
More route identity work

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1379,7 +1379,7 @@ impl ListTypeIdentifier {
 // quotes. We don't do any escaping or anything like that.
 
 // StringLiteral ::= '"' Identifier '"'
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StringLiteral(pub(crate) String);
 
 impl StringLiteral {

--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use std::marker::PhantomData;
 use std::ops::Index;
 
+use crate::ast::StringLiteral;
 use crate::types::builtin::{
     AsPath, Asn, AtomicAggregator, BuiltinTypeValue, Community, IpAddress,
     LocalPref, MultiExitDisc, NextHop, OriginType, Prefix, RouteStatus,
@@ -58,6 +59,7 @@ impl ScalarValue for Prefix {}
 impl ScalarValue for RouteStatus {}
 impl ScalarValue for IpAddress {}
 impl ScalarValue for Asn {}
+impl ScalarValue for StringLiteral {}
 // impl ScalarValue for (u8, u32) {}
 
 //------------ Attributes Change Set ----------------------------------------
@@ -88,6 +90,8 @@ pub struct AttrChangeSet {
     pub peer_ip: ScalarOption<IpAddress>,
     #[serde(skip_serializing_if = "ScalarOption::is_none")]
     pub peer_asn: ScalarOption<Asn>,
+    #[serde(skip_serializing_if = "ScalarOption::is_none")]
+    pub router_id: ScalarOption<StringLiteral>,
     // mp_reach_nlri: Vec<Prefix>,
     // mp_unreach_nlri: Vec<Prefix>,
     #[serde(skip)]


### PR DESCRIPTION
This PR fixes two "issues" with the current implementation of "route identity":

1. Any set peer IP and peer ASN (identifying the peer that originated the route) were lost on conversion to `MaterializedRoute`.
2. There was no notion of the "router" from which the route was received, which we want to keep track of.

For BMP the router that we received the route from is a BMP monitoring station which is likely not the router that originated the route (which is instead the router identified by peer IP and ASN).

For BMP a monitoring station could be identified by its source TCP IP/port, or by the `sysName` TLV supplied in the mandatory BMP Initiation message, or maybe even a name supplied by the operator via configuration.

For BGP no equivalent to the `sysName` is available, but we may still want to support identifying the router by something richer than, or in addition to, its source TCP IP/port, such as a name supplied by the operator via configuration.

As such this PR records the source router ID as a String, behind an Arc as it will appear on many routes. If it is a short string the Arc size might actually exceed the string size, for longer strings the Arc size will be less.

One could make an argument for creating a separate type for the router ID, maybe even that chooses String vs Arc<String> based on ID length, or one could also reference a central table of number -> String mappings, but then that would still presumably need to be at least a u16 (u8 seems too small, we already have tests with around 200 connected BMP monitoring stations which is approaching the u8 limit of 255) and would need to be transformed to an actual string if serialized for sending over the wire e.g. via any future `Rotoro` communication protocol.