### PR TITLE
Serialize ShortString and Record like String and Map.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2709,11 +2709,11 @@ impl PrefixLengthRange {
 
 #[derive(Clone, Serialize)]
 pub struct ShortString {
-    #[serde(serialize_with = "short_string_serialize")]
+    #[serde(serialize_with = "serialize_short_string")]
     bytes: SmallVec<[u8; 24]>,
 }
 
-fn short_string_serialize<S>(short_string: &SmallVec<[u8; 24]>, s: S) -> Result<S::Ok, S::Error>
+fn serialize_short_string<S>(short_string: &SmallVec<[u8; 24]>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2803,7 +2803,8 @@ impl fmt::Debug for ShortString {
 impl Serialize for ShortString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer {
+        S: Serializer
+    {
         serializer.serialize_str(self)
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2707,20 +2707,9 @@ impl PrefixLengthRange {
 
 //------------ ShortString ---------------------------------------------------
 
-#[derive(Clone, Serialize)]
+#[derive(Clone)]
 pub struct ShortString {
-    #[serde(serialize_with = "serialize_short_string")]
     bytes: SmallVec<[u8; 24]>,
-}
-
-fn serialize_short_string<S>(short_string: &SmallVec<[u8; 24]>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match str::from_utf8(short_string.as_slice()) {
-        Ok(v) => s.serialize_str(v),
-        Err(err) => Err(serde::ser::Error::custom(&format!("ShortString contains invalid UTF-8 characters: {err}"))),
-    }
 }
 
 impl ShortString {
@@ -2808,5 +2797,13 @@ impl fmt::Display for ShortString {
 impl fmt::Debug for ShortString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl Serialize for ShortString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer {
+        serializer.serialize_str(self)
     }
 }

--- a/src/types/collections.rs
+++ b/src/types/collections.rs
@@ -616,9 +616,7 @@ impl From<ListToken> for usize {
 // variant, including Lists and Records.
 
 #[derive(Debug, PartialEq, Eq, Default, Clone, Hash)]
-pub struct Record(
-    Vec<(ShortString, ElementTypeValue)>
-);
+pub struct Record(Vec<(ShortString, ElementTypeValue)>);
 
 impl<'a> Record {
     pub(crate) fn new(


### PR DESCRIPTION
As the title says this PR adjusts the serialization of some Roto String- and Map- like types to be String and Map like.