### PR TITLE
remove {IpAddress,Prefix}Literal types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ rotonda-store   = { version = "0.3.0" }
 
 [dev-dependencies]
 env_logger  = "0.10"
-routes      = { version = "0.1.0" }
+routes      = { git = "https://github.com/nlnetlabs/routes", branch = "main" }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3344,7 +3344,7 @@ pub struct Ipv4Addr(pub std::net::Ipv4Addr);
 impl Ipv4Addr {
     fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         let (input, ip_addr_str) = context(
-            "IpV4 Literal",
+            "IPv4 Literal",
             recognize(tuple((
                 terminated(digit1, char('.')),
                 terminated(digit1, char('.')),
@@ -3376,7 +3376,7 @@ pub struct Ipv6Addr(pub std::net::Ipv6Addr);
 impl Ipv6Addr {
     fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         let (input, ip_addr_str) = context(
-            "IpV6 Literal",
+            "IPv6 Literal",
             recognize(tuple((
                 terminated(hex_digit0, char(':')),
                 opt(terminated(hex_digit0, char(':'))),

--- a/src/types/builtin/tests.rs
+++ b/src/types/builtin/tests.rs
@@ -5,7 +5,7 @@ mod route {
     use super::super::{
         IntegerLiteral, PrefixLength, StringLiteral,
     };
-    use crate::ast::{IpAddressLiteral, AsnLiteral};
+    use crate::ast::{AsnLiteral, IpAddress};
     use crate::types::builtin::BuiltinTypeValue;
     use crate::types::typedef::TypeDef;
     use crate::types::typevalue::TypeValue;
@@ -1087,7 +1087,7 @@ src_ty.clone().test_type_conversion(arg_ty)"]
     fn test_ip_address_literal_1() -> Result<(), CompileError> {
         init();
 
-        let test_value = IpAddr::try_from(&IpAddressLiteral("24.0.2.0".to_string())).unwrap();
+        let test_value = IpAddr::from(&IpAddress::parse("24.0.2.0").unwrap().1);
         let res = std::net::IpAddr::from([24,0,2,0]);
         mk_converted_type_value(test_value, res)
     }
@@ -1096,7 +1096,7 @@ src_ty.clone().test_type_conversion(arg_ty)"]
     fn test_ip_address_literal_2() -> Result<(), CompileError> {
         init();
 
-        let test_value = IpAddr::try_from(&IpAddressLiteral("24.0.2.0".to_string())).unwrap();
+        let test_value = IpAddr::from(&IpAddress::parse("24.0.2.0").unwrap().1);
         let res = StringLiteral("24.0.2.0".into());
         mk_converted_type_value(test_value, res)
     }
@@ -1105,7 +1105,7 @@ src_ty.clone().test_type_conversion(arg_ty)"]
     fn test_ip_address_literal_3() -> Result<(), CompileError> {
         init();
 
-        let test_value = IpAddr::try_from(&IpAddressLiteral("2001::ffff".to_string())).unwrap();
+        let test_value = IpAddr::from(&IpAddress::parse("2001::ffff").unwrap().1);
         let res = std::net::IpAddr::from([0x2001,0x0,0x0,0x0,0x0,0x0,0x0,0xffff]);
 
         assert_eq!(TypeValue::from(test_value).into_builtin()?, BuiltinTypeValue::IpAddr(res));

--- a/src/types/typevalue.rs
+++ b/src/types/typevalue.rs
@@ -1197,24 +1197,15 @@ impl From<crate::ast::IntegerLiteral> for TypeValue {
     }
 }
 
-impl TryFrom<&'_ crate::ast::IpAddressLiteral> for TypeValue {
-    type Error = CompileError;
-
-    fn try_from(
-        value: &crate::ast::IpAddressLiteral,
-    ) -> Result<Self, Self::Error> {
-        Ok(TypeValue::Builtin(BuiltinTypeValue::IpAddr(
-            value.try_into()?,
-        )))
+impl From<&'_ crate::ast::IpAddress> for TypeValue {
+    fn from(value: &crate::ast::IpAddress) -> Self {
+        TypeValue::Builtin(BuiltinTypeValue::IpAddr(value.into()))
     }
 }
 
-impl TryFrom<&'_ crate::ast::PrefixLiteral> for TypeValue {
+impl TryFrom<&'_ crate::ast::Prefix> for TypeValue {
     type Error = CompileError;
-
-    fn try_from(
-        value: &crate::ast::PrefixLiteral,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: &crate::ast::Prefix) -> Result<Self, Self::Error> {
         Ok(TypeValue::Builtin(BuiltinTypeValue::Prefix(
             value.try_into()?,
         )))


### PR DESCRIPTION
I noticed that that the following types all exist right now:

- `IpAddress`
- `IpAddressLiteral`
- `Prefix`
- `PrefixLiteral`

We can just parse all of them directly to the non-literal version and remove this duplication. This simplifies the parsing a bit, especially in the parser I'm working on, but I separated this out.