### PR TITLE
Convert comments to doc comments where sensible

### DIFF
--- a/src/attr_change_set.rs
+++ b/src/attr_change_set.rs
@@ -58,8 +58,8 @@ pub trait ScalarValue: Clone + Into<TypeValue> {}
 
 //------------ Attributes Change Set ----------------------------------------
 
-// A attributes Change Set allows a user to create a set of changes to an
-// existing (raw) BGP Update message.
+/// A attributes Change Set allows a user to create a set of changes to an
+/// existing (raw) BGP Update message.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Hash)]
 pub struct AttrChangeSet {
     #[serde(skip_serializing_if = "ReadOnlyScalarOption::is_none")]

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -4,19 +4,19 @@ use crate::ast::ShortString;
 
 //------------ Scope --------------------------------------------------------
 
-// A scope identifies a roto block (its quality: Unit, Module, Filter,
-// FilterMap, Module) and describes its scope.
-
+/// A scope identifies a roto block (its quality: Unit, Module, Filter,
+/// FilterMap, Module) and describes its scope.
 #[derive(Debug, Eq, Clone)]
 pub enum Scope {
-    // The Global Scope. Holds all user-defined types,
-    // global constant enums. May also get some
-    // methods in the long run.
+    /// The Global Scope.
+    ///
+    /// Holds all user-defined types, global constant enums.
+    /// May also get some methods in the long run.
     Global,
-    // The Scope of one FilterMap block, holds everyth ing
-    // from its define section
+    /// The Scope of one FilterMap block, holds everything
+    /// from its define section
     FilterMap(ShortString),
-    // The Scope of a Filter, idem.
+    /// The Scope of a Filter, holds everthing form its define section
     Filter(ShortString),
 }
 
@@ -40,9 +40,9 @@ impl Display for Scope {
     }
 }
 
-// Define equivalence for two Scopes if their names match, meaning a user
-// should not be allowed to create two blocks with the same name even though
-// they are different block types.
+/// Define equivalence for two Scopes if their names match, meaning a user
+/// should not be allowed to create two blocks with the same name even though
+/// they are different block types.
 impl PartialEq for Scope {
     fn eq(&self, other: &Self) -> bool {
         match self {

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -1,11 +1,11 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompileError {
-    // An error that we - the Roto compiler - think is caused by the Roto
-    // end-user, through a Roto script.
+    /// An error that we - the Roto compiler - think is caused by the Roto
+    /// end-user, through a Roto script.
     User(String),
-    // A logical error caused by internal inconsistency in the Roto compiler.
+    /// A logical error caused by internal inconsistency in the Roto compiler.
     Internal(String),
-    // An error with no discernable cause, this is very worrying, btw.
+    /// An error with no discernable cause, this is very worrying, btw.
     Unspecified
 }
 

--- a/src/compiler/recurse_compile.rs
+++ b/src/compiler/recurse_compile.rs
@@ -11,9 +11,9 @@ use crate::types::typedef::TypeDef;
 use crate::types::typevalue::TypeValue;
 use crate::vm::{Command, CommandArg, CompiledCollectionField, OpCode, VmError, FieldIndex};
 
-// This function is the heart of the compiler, all the recursion in the
-// compilation process happens here. The other compile_* functions just
-// trigger this function to recurse into the symbols map.
+/// This function is the heart of the compiler, all the recursion in the
+/// compilation process happens here. The other compile_* functions just
+/// trigger this function to recurse into the symbols map.
 pub(crate) fn recurse_compile<'a>(
     symbol: &'a Symbol,
     mut state: CompilerState<'a>,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2442,19 +2442,22 @@ fn check_type_identifier(
     .into())
 }
 
-// This function checks if a variable exists in the scope of the filter_map,
-// but not in the global scope (variables in the global scope are not
-// allowed). The variables can be of form:
-// <var_name>
-// <var of type Record>[.<field>]+
-//
-// In the last case the whole form may live in the filter_map scope as an
-// anonymous type (deducted from user-defined record-types), but in the case
-// of a primitive type they live in the user-defined record-type itself.
-//
-// The last value in the return tuple is a builtin-typed value in case it's
-// present in the symbol, this should only be the case with a Constant,
-// containing a literal value.
+/// Retrieve a variable that is not in the global scope
+///
+/// This function checks if a variable exists in the scope of the `filter_map`,
+/// but not in the global scope (variables in the global scope are not
+/// allowed). The variables can be of form:
+///
+/// - `<var_name>`
+/// - `<var of type Record>[.<field>]+`
+///
+/// In the last case the whole form may live in the `filter_map` scope as an
+/// anonymous type (deducted from user-defined record-types), but in the case
+/// of a primitive type they live in the user-defined record-type itself.
+///
+/// The last value in the return tuple is a builtin-typed value in case it's
+/// present in the symbol, this should only be the case with a Constant,
+/// containing a literal value.
 fn get_props_for_scoped_variable(
     fields: &[ast::Identifier],
     symbols: GlobalSymbolTable,
@@ -2975,8 +2978,8 @@ fn is_boolean_function(
     }
 }
 
-// A boolean expression only accepts on expression, that should return a
-// boolean value.
+/// A boolean expression only accepts on expression, that should return a
+/// boolean value.
 fn _is_boolean_expression(
     expr: &impl BooleanExpr,
 ) -> Result<(), CompileError> {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -24,8 +24,7 @@ use crate::{
 
 //------------ Symbols ------------------------------------------------------
 
-// The only symbols we really have are variables & (user-defined) types.
-
+/// The only symbols we really have are variables & (user-defined) types.
 #[derive(Debug, Eq)]
 pub(crate) struct Symbol {
     name: ShortString,
@@ -163,11 +162,11 @@ impl Symbol {
         }
     }
 
-    // checks to see if the arguments (`args`) in this symbol match with the
-    // supplied `type_def` or if all the subtypes can be converted into the
-    // subtypes of `type_def`. It will recognize anonymous sub-records. It it
-    // can work this out it will return the a Vec with the name of the
-    // (sub)-field, its (converted) type and its (converted) TypeValue.
+    /// Checks to see if the arguments (`args`) in this symbol match with the
+    /// supplied `type_def` or if all the subtypes can be converted into the
+    /// subtypes of `type_def`. It will recognize anonymous sub-records. If it
+    /// can work this out it will return the a `Vec` with the name of the
+    /// (sub)-field, its (converted) type and its (converted) [`TypeValue`].
     pub fn get_recursive_values_primitive(
         &self,
         type_def: TypeDef,
@@ -275,8 +274,8 @@ impl Symbol {
         self.args.as_slice()
     }
 
-    // Bounds checking #1: Check if the first actually exists before actually
-    // returning it.
+    /// Bounds checking #1: Check if the first actually exists before actually
+    /// returning it.
     pub fn get_first_arg_checked(&self) -> Result<&Symbol, CompileError> {
         if let Some(first) = self.args.first() {
             Ok(first)
@@ -288,8 +287,8 @@ impl Symbol {
         }
     }
 
-    // Bounds checking #2: Check if there are a specified number of arguments
-    // before returning the number of specified arguments.
+    /// Bounds checking #2: Check if there are a specified number of arguments
+    /// before returning the number of specified arguments.
     pub fn get_args_checked(
         &self,
         num: usize,
@@ -304,8 +303,8 @@ impl Symbol {
         }
     }
 
-    // Bounds checking #3: Check if a minimum number of arguments is present,
-    // and then returning all of the arguments.
+    /// Bounds checking #3: Check if a minimum number of arguments is present,
+    /// and then returning all of the arguments.
     pub fn get_args_with_checked_min_len(
         &self,
         min_len: usize,
@@ -324,8 +323,8 @@ impl Symbol {
         &mut self.args
     }
 
-    // Go into the first arg of a symbol until we find a empty args vec and
-    // store it there.
+    /// Go into the first arg of a symbol until we find a empty args vec and
+    /// store it there.
     pub fn add_arg(&mut self, arg: Symbol) -> usize {
         self.args.push(arg);
         self.args.len() - 1
@@ -376,12 +375,12 @@ impl Symbol {
         }
     }
 
-    // Return the type of:
-    // - this symbol if it represents a Record OR
-    // - this symbol if it's a leaf node (args are empty) OR
-    // - the last symbol of the args, if that's a leaf node OR
-    // Used to construct the return type of a variable that is being
-    // assigned.
+    /// Return the type of:
+    /// - this symbol if it represents a Record OR
+    /// - this symbol if it's a leaf node (args are empty) OR
+    /// - the last symbol of the args, if that's a leaf node OR
+    /// Used to construct the return type of a variable that is being
+    /// assigned.
     pub(crate) fn get_recursive_return_type(&self) -> TypeDef {
         if let TypeDef::Record(_ty) = self.get_type() {
             return self.ty.clone();
@@ -395,10 +394,10 @@ impl Symbol {
         }
     }
 
-    // This function tries to convert a symbol with a given type into a symbol
-    // with another type and set its value according to the new type, if it
-    // has a a value. If the conversion is not possible it returns an error.
-    // Used during the evaluation phase.
+    /// This function tries to convert a symbol with a given type into a symbol
+    /// with another type and set its value according to the new type, if it
+    /// has a a value. If the conversion is not possible it returns an error.
+    /// Used during the evaluation phase.
     pub fn try_convert_type_value_into(
         mut self,
         into_ty: TypeDef,
@@ -623,33 +622,33 @@ impl TryFrom<SymbolKind> for MatchActionType {
 
 //------------ SymbolTable --------------------------------------------------
 
-// A per-filter-map symbol table.
+/// A per-filter-map symbol table.
 #[derive(Debug)]
 pub struct SymbolTable {
     scope: Scope,
-    // The input payload type of the filter_map.
+    /// The input payload type of the `filter_map`.
     rx_type: Symbol,
-    // The output payload type of the filter_map. If it's none its identical
-    // to the input payload type.
+    /// The output payload type of the `filter_map`. If it's none its identical
+    /// to the input payload type.
     tx_type: Option<Symbol>,
-    // The special symbols that will be filled in at runtime, once per filter
-    // run.
+    /// The special symbols that will be filled in at runtime, once per filter
+    /// run.
     arguments: HashMap<ShortString, Symbol>,
-    // The variables and constants that are defined in the filter_map.
+    /// The variables and constants that are defined in the `filter_map`.
     variables: HashMap<ShortString, Symbol>,
-    // The evaluated `term` sections that are defined in the filter_map.
+    /// The evaluated `term` sections that are defined in the `filter_map`.
     term_sections: HashMap<ShortString, Symbol>,
-    // The evaluated `action` sections that are defined in the filter_map.
+    /// The evaluated `action` sections that are defined in the `filter_map`.
     action_sections: HashMap<ShortString, Symbol>,
-    // All the `filter` clauses in the `apply` section, the tie actions to
-    // terms.
+    /// All the `filter` clauses in the `apply` section, the tie actions to
+    /// terms.
     match_action_sections: Vec<MatchAction>,
-    // the action that will be activated when all of the match_actions are
-    // processed and no early return has been issued
+    /// The action that will be activated when all of the match_actions are
+    /// processed and no early return has been issued
     default_action: crate::ast::AcceptReject,
 }
 
-// The global symbol table.
+/// The global symbol table.
 #[derive(Debug)]
 pub struct GlobalSymbolTable(
     Rc<
@@ -1016,10 +1015,12 @@ impl SymbolTable {
             })
     }
 
-    // Retrieve the symbol from the `variables` table of a filter_map the
-    // entry Used in the compile stage to build the command stack.
-
-    // panics if the symbol is not found.
+    /// Retrieve the symbol from the `variables` table of a `filter_map` the
+    /// entry.
+    ///
+    /// Used in the compile stage to build the command stack.
+    ///
+    /// Panics if the symbol is not found.
     pub(crate) fn get_variable_by_token(
         &self,
         token: &Token,
@@ -1074,8 +1075,8 @@ impl SymbolTable {
             .map(|term| (term.ty.clone(), term.token.clone()))
     }
 
-    // Return the type of the first argument of the symbol that lives in this
-    // hashmap, used by the evaluator when looking to resolve arguments.
+    /// Return the type of the first argument of the symbol that lives in this
+    /// hashmap, used by the evaluator when looking to resolve arguments.
     pub(crate) fn get_type_of_argument(
         &self,
         name: &ShortString,
@@ -1151,9 +1152,9 @@ impl SymbolTable {
         })?
     }
 
-    // retrieve all the unique arguments, variables and data-sources that are
-    // referenced in the terms field of a symbol table (i.e. the terms
-    // sections in a filter_map)
+    /// Retrieve all the unique arguments, variables and data-sources that are
+    /// referenced in the terms field of a symbol table (i.e. the terms
+    /// sections in a `filter_map`)
     pub(crate) fn create_deps_graph(
         &self,
     ) -> Result<

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -17,58 +17,58 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize)]
 pub enum Token {
-    // A value represented by the index of the entry in the `local_variables`
-    // VariableRefTable of the CompilerState.
+    /// A value represented by the index of the entry in the `variables`
+    /// field of the [`SymbolTable`](crate::symbols::SymbolTable).
     Variable(usize),
     Method(usize),
     Variant(usize),
     Argument(usize),
-    // Action Sections can have arguments passed in, a symbol labelled with
-    // this token references that argument. The first usize represents the
-    // index of the TermSection for which it is the `with` argument. The
-    // second usize is the index of the `with` argument per TermSection. For
-    // now this is always zero (only one argument per TermSection allowed).
+    /// Action Sections can have arguments passed in, a symbol labelled with
+    /// this token references that argument. The first usize represents the
+    /// index of the TermSection for which it is the `with` argument. The
+    /// second usize is the index of the `with` argument per `TermSection`. For
+    /// now this is always zero (only one argument per `TermSection` allowed).
     ActionArgument(usize, usize),
-    // Idem but for Terms
+    /// Terms, similar to `Token::ActionArgument`
     TermArgument(usize, usize),
-    // There can only ever be one RxType
+    /// There can only ever be one RxType
     RxType(TypeDef),
-    // There can only ever be one TxType too
+    /// There can only ever be one TxType too
     TxType,
-    // External Data Sources
+    /// External Data Sources
     Table(usize),
     Rib(usize),
-    // A generic stream that can be used by Roto to send messages to and that
-    // can be configured through a Roto script, e.g. a Kafka or a MQTT stream.
+    /// A generic stream that can be used by Roto to send messages to and that
+    /// can be configured through a Roto script, e.g. a Kafka or a MQTT stream.
     OutputStream(usize),
-    // A mapping to the (recursive) field of a record, the first u8 is a
-    // numbered field of the record, the second points into the first
-    // sub-field etc.
+    /// A mapping to the (recursive) field of a record, the first `u8` is a
+    /// numbered field of the record, the second points into the first
+    /// sub-field etc.
     FieldAccess(Vec<u8>),
-    // A numbered term section that was found in the evaluated symbol map.
+    /// A numbered term section that was found in the evaluated symbol map.
     TermSection(usize),
-    // A term that is used only once (in a match expression) and will be
-    // compiled at the spot.
+    /// A term that is used only once (in a match expression) and will be
+    /// compiled at the spot.
     AnonymousTerm,
     ActionSection(usize),
     NoAction,
     MatchAction(usize),
-    // None as data indicates a constant that wasn't stored (yet) in the
-    // symbol table.
+    /// `None`` as data indicates a constant that wasn't stored (yet) in the
+    /// symbol table.
     Constant(Option<usize>),
-    // An anonymous record, the fields live in the `args` vec of the
-    // symbol.
+    /// An anonymous record, the fields live in the `args` vec of the
+    /// symbol.
     AnonymousRecord,
     TypedRecord,
     List,
     BuiltinType(u8),
-    // A named, hard-coded global Enum
+    /// A named, hard-coded global Enum
     Enum(GlobalEnumTypeDef),
-    // Anonymous Enum
+    /// Anonymous Enum
     AnonymousEnum,
     ConstEnumVariant,
-    // Some structural symbols that are non-terminal, meaning they have
-    // children, may not have to need any Token.
+    /// Some structural symbols that are non-terminal, meaning they have
+    /// children, may not have to need any Token.
     NonTerminal,
 }
 
@@ -127,7 +127,6 @@ impl TryFrom<Token> for usize {
     }
 }
 
-// impl From for Field Index.
 impl TryFrom<Token> for FieldIndex {
     type Error = CompileError;
 

--- a/src/types/builtin/bmp_message.rs
+++ b/src/types/builtin/bmp_message.rs
@@ -98,10 +98,10 @@ impl EnumBytesRecord for BytesRecord<BmpMessage> {
         self.0.common_header().msg_type().into()
     }
 
-    // Returns the TypeValue for a variant and field_index on this
-    // bytes_record. Returns a TypeValue::Unknown if the requested
-    // variant does not match the bytes record. Returns an error if
-    // no field_index was specified.
+    /// Returns the [`TypeValue`] for a variant and field_index on this
+    /// `bytes_record`. Returns a [`TypeValue::Unknown`] if the requested
+    /// variant does not match the bytes record. Returns an error if
+    /// no field_index was specified.
     fn get_field_index_for_variant(
         &self,
         variant_token: LazyRecordTypeDef,
@@ -249,7 +249,7 @@ impl From<MessageType> for LazyRecordTypeDef {
 
 //------------ BmpRouteMonitoringMessage -------------------------------------
 
-// THe fields of a bytes_record_impl should be STRICTLY alphabetically ordered
+// The fields of a bytes_record_impl should be STRICTLY alphabetically ordered
 // by the the name of the key and numbered in that order.
 
 bytes_record_impl!(
@@ -311,7 +311,7 @@ impl BytesRecord<RouteMonitoring> {
 
 //------------ PeerUpNotification -------------------------------------------
 
-// THe fields of a bytes_record_impl should be STRICTLY alphabetically
+// The fields of a bytes_record_impl should be STRICTLY alphabetically
 // ordered by the the name of the key and numbered in that order.
 
 bytes_record_impl!(

--- a/src/types/builtin/primitives.rs
+++ b/src/types/builtin/primitives.rs
@@ -1601,10 +1601,11 @@ impl VectorValue for routecore::bgp::aspath::HopPath {
         Ok(())
     }
 
-    // Naïve insert that will try to append to the segment that is already in
-    // place at the specified position. Fancier, more conditional ways are
-    // available to the roto user, but those methods are implemented directly
-    // on builtin::AsPath.
+    /// Naïve insert that will try to append to the segment that is already in
+    /// place at the specified position.
+    /// 
+    /// Fancier, more conditional ways are available to the roto user, but
+    /// those methods are implemented directly on [`builtin::AsPath`].
     fn insert_vec(
         &mut self,
         pos: u8,

--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -270,8 +270,8 @@ impl RawRouteWithDeltas {
         self.status_deltas.0.push(delta);
     }
 
-    // Get a clone of the latest delta, or of the original attributes from
-    // the raw message, if no delta has been added (yet).
+    /// Get a clone of the latest delta, or of the original attributes from
+    /// the raw message, if no delta has been added (yet).
     fn clone_latest_attrs(&self) -> Result<AttrChangeSet, VmError> {
         if let Some(attr_set) = self.attribute_deltas.deltas.last() {
             Ok(attr_set.attributes.clone())
@@ -287,8 +287,8 @@ impl RawRouteWithDeltas {
         }
     }
 
-    // Return a clone of the latest attribute set, so that changes can be
-    // made to it by the caller.
+    //// Return a clone of the latest attribute set, so that changes can be
+    //// made to it by the caller.
     pub fn open_new_delta(
         &mut self,
         delta_id: (RotondaId, LogicalTime),
@@ -302,9 +302,9 @@ impl RawRouteWithDeltas {
         })
     }
 
-    // Get either the moved last delta (it is removed from the Delta list), or
-    // get a freshly rolled ChangeSet from the raw message, if there are no
-    // deltas.
+    /// Get either the moved last delta (it is removed from the Delta list), or
+    /// get a freshly rolled ChangeSet from the raw message, if there are no
+    /// deltas.
     pub fn take_latest_attrs(mut self) -> Result<AttrChangeSet, VmError> {
         if self.attribute_deltas.deltas.is_empty() {
             return self.raw_message.raw_message.create_changeset(
@@ -358,7 +358,7 @@ impl RawRouteWithDeltas {
             })
     }
 
-    // Get a ChangeSet that was added by a specific unit, e.g. a filter.
+    /// Get an [`AttrChangeSet`] that was added by a specific unit, e.g. a filter.
     pub fn get_delta_for_rotonda_id(
         &self,
         rotonda_id: RotondaId,
@@ -370,7 +370,7 @@ impl RawRouteWithDeltas {
             .map(|d| &d.attributes)
     }
 
-    // Add a ChangeSet with some metadata to this RawRouteWithDelta.
+    /// Add a [`AttributeDelta`] with some metadata to this [`RawRouteWithDeltas`].
     pub fn store_delta(
         &mut self,
         attr_delta: AttributeDelta,
@@ -633,17 +633,17 @@ impl RawRouteWithDeltas {
 
 //------------ RouteDeltas --------------------------------------------------
 
-// The history of changes to this route. Each Delta holds the attributes that
-// were originally present in the raw message, their modifications and newly
-// created ones.
-//
-// The list of deltas describes the changes that were made by one Rotonda
-// unit along the way.
+/// The history of changes to this route. Each Delta holds the attributes that
+/// were originally present in the raw message, their modifications and newly
+/// created ones.
+///
+/// The list of deltas describes the changes that were made by one Rotonda
+/// unit along the way.
 #[derive(Debug, Clone, Eq, PartialEq, Default, Hash, Serialize)]
 struct AttributeDeltaList {
     deltas: Vec<AttributeDelta>,
-    // The delta that was handed out the most recently. This is the only
-    // delta that can be written back!
+    /// The delta that was handed out the most recently. This is the only
+    /// delta that can be written back!
     locked_delta: Option<usize>,
 }
 
@@ -655,12 +655,12 @@ impl AttributeDeltaList {
         }
     }
 
-    // Gets the most recently added delta in this list.
+    /// Gets the most recently added delta in this list.
     fn get_latest_change_set(&self) -> Option<&AttrChangeSet> {
         self.deltas.last().map(|d| &d.attributes)
     }
 
-    // Adds a new delta to the list.
+    /// Adds a new delta to the list.
     fn store_delta(&mut self, delta: AttributeDelta) -> Result<(), VmError> {
         if let Some(locked_delta) = self.locked_delta {
             if locked_delta != delta.delta_index {
@@ -688,8 +688,8 @@ impl AttributeDeltaList {
 
 //------------ AttributeDelta ----------------------------------------------
 
-// A set of attribute changes that were atomically created by a Rotonda
-// unit in one go (with one logical timestamp).
+/// A set of attribute changes that were atomically created by a Rotonda
+/// unit in one go (with one logical timestamp).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
 pub struct AttributeDelta {
     delta_id: (RotondaId, LogicalTime),
@@ -754,13 +754,13 @@ impl RouteStatusDeltaList {
 
 //------------ BgpUpdateMessage ------------------------------------------------
 
-// A data-structure that stores the array of bytes of the incoming BGP Update
-// message, together with its logical timestamp and an ID of the instance
-// and/or unit that received it originally.
-//
-// The `attr_cache` AttributeList allows readers to get a reference to a path
-// attribute. This avoids having to clone from the AttributeLists in the
-// iterator over the latest attributes.
+/// A data-structure that stores the array of bytes of the incoming BGP Update
+/// message, together with its logical timestamp and an ID of the instance
+/// and/or unit that received it originally.
+///
+/// The `attr_cache` `AttributeList` allows readers to get a reference to a path
+/// attribute. This avoids having to clone from the `AttributeList`s in the
+/// iterator over the latest attributes.
 #[derive(Debug, Clone, Serialize)]
 pub struct BgpUpdateMessage {
     message_id: (RotondaId, LogicalTime),
@@ -1354,9 +1354,9 @@ impl UpdateMessage {
             )
     }
 
-    // Materialize a ChangeSet from the Update message. The materialized
-    // Change set is completely self-contained (no references of any kind) &
-    // holds all the attributes of the current BGP Update message.
+    /// Materialize a [`AttrChangeSet`] from the Update message. The materialized
+    /// change-set is completely self-contained (no references of any kind) &
+    /// holds all the attributes of the current BGP Update message.
     pub fn create_changeset(
         &self,
         prefix: Prefix,
@@ -1429,8 +1429,8 @@ impl UpdateMessage {
         })
     }
 
-    // Create a new BGP Update message by applying the attributes changes
-    // in the supplied change set to our current Update message.
+    /// Create a new BGP Update message by applying the attributes changes
+    /// in the supplied change set to our current Update message.
     pub fn create_update_from_changeset<T: ScalarValue, V: VectorValue>(
         _change_set: &AttrChangeSet,
     ) -> Self {

--- a/src/types/collections.rs
+++ b/src/types/collections.rs
@@ -1,3 +1,39 @@
+//! Roughly the collection types fall into two categories: Materialized
+//! collections and their element types, and lazy evaluated collection types
+//! and their element types.
+//!
+//! The materialized collection types are Record and List. The element type for
+//! both is called ElementTypeValue. The latter has the ability to store nested
+//! TypeValues, so the roto user can create/modify things like Lists of lists,
+//! or Record with List-typed fields. The collection types themselves are
+//! straight-forward vectors of ElementTypeValues (with a ShortString added for
+//! the Record type). The List type is ordered (order of insert), the Record
+//! type MUST be ordered alphabetically by key. The Roto user should not have
+//! to worry about this, though.
+//!
+//! The lazy types are BytesRecord and LazyRecord. BytesRecord is the type that
+//! wraps the more complex routecore types, mainly the different BMP message
+//! types. They are a wrapper around this message. A LazyRecord is a special
+//! type that provides the translation between the method calls on a routecore
+//! type and the corresponding fields that are offered to the roto user. So,
+//! from the perspective of the roto user a LazyRecord is just a regular
+//! Record, with (field_name, value) pairs. The LazyRecord type instances
+//! *cannot* be stored in a TypeValue enum, they are strictly to be used as
+//! intermediary types inside a Rotonda instance. If they need to be stored
+//! (e.g. in a RIB), they need to be materialized first. Materializing them
+//! only makes sense when the Roto user has modified them, otherwise it's
+//! advisable to store the related BytesRecord, which *do* have
+//! BuiltinTypeValue variants to store them in, e.g. BuiltinTypeValue::
+//! BmpMessage. Each BytesRecord type has a variant in the `LazyRecordTypeDef`
+//! enum, so this acts as a registry for them (see LazyRecord_types).
+//!
+//! There's also an `EnumBytesRecord` trait that should be implemented for
+//! BytesRecord types that contain an enum, e.g. `BytesRecord<BmpMessage>`. This
+//! allows the roto user to create a match pattern on them.
+//!
+//! Note that the roto user should not be have to worry about or ever be
+//! confronted with the lazy evaluated types.
+
 use log::{trace, error, debug};
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
@@ -17,50 +53,11 @@ use super::lazyrecord_types::LazyRecordTypeDef;
 use super::typedef::{LazyNamedTypeDef, MethodProps, TypeDef};
 use super::typevalue::TypeValue;
 
-//============ Collections ==================================================
-
-// Roughly the collection types fall into two categories: Materialized
-// collections and their element types, and lazy evaluated collection types
-// and their element types.
-
-// The materialized collection types are Record and List. The element type for
-// both is called ElementTypeValue. The latter has the ability to store nested
-// TypeValues, so the roto user can create/modify things like Lists of lists,
-// or Record with List-typed fields. The collection types themselves are
-// straight-forward vectors of ElementTypeValues (with a ShortString added for
-// the Record type). The List type is ordered (order of insert), the Record
-// type MUST be ordered alphabetically by key. The Roto user should not have
-// to worry about this, though.
-
-// The lazy types are BytesRecord and LazyRecord. BytesRecord is the type that
-// wraps the more complex routecore types, mainly the different BMP message
-// types. They are a wrapper around this message. A LazyRecord is a special
-// type that provides the translation between the method calls on a routecore
-// type and the corresponding fields that are offered to the roto user. So,
-// from the perspective of the roto user a LazyRecord is just a regular
-// Record, with (field_name, value) pairs. The LazyRecord type instances
-// *cannot* be stored in a TypeValue enum, they are strictly to be used as
-// intermediary types inside a Rotonda instance. If they need to be stored
-// (e.g. in a RIB), they need to be materialized first. Materializing them
-// only makes sense when the Roto user has modified them, otherwise it's
-// advisable to store the related BytesRecord, which *do* have
-// BuiltinTypeValue variants to store them in, e.g. BuiltinTypeValue::
-// BmpMessage. Each BytesRecord type has a variant in the `LazyRecordTypeDef`
-// enum, so this acts as a registry for them (see LazyRecord_types).
-
-// There's also an `EnumBytesRecord` trait that should be implemented for
-// BytesRecord types that contain an enum, e.g. BytesRecord<BmpMessage>. This
-// allows the roto user to create a match pattern on them.
-
-// Note that the roto user should not be have to worry about or ever be
-// confronted with the lazy evaluated types.
-
 //------------ ElementType --------------------------------------------------
 
-// This enum is used to differentiate between recursive collections and
-// simple collections (that only contain primitive types). The latter do not
-// need to be boxed, while the former do.
-
+/// This enum is used to differentiate between recursive collections and
+/// simple collections (that only contain primitive types). The latter do not
+/// need to be boxed, while the former do.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize)]
 #[serde(untagged)]
 pub enum ElementTypeValue {
@@ -201,10 +198,10 @@ impl Default for ElementTypeValue {
     }
 }
 
-// Conversion for Records. Records hold `ElementTypeValue`s, the literals
-// provided by the user in a a Roto script need to be converted. This returns
-// a Result because the conversion may fail in the eval() phase, where we have
-// syntactically correct structures, but they overflow or have unknown values.
+/// Conversion for Records. Records hold `ElementTypeValue`s, the literals
+/// provided by the user in a a Roto script need to be converted. This returns
+/// a Result because the conversion may fail in the eval() phase, where we have
+/// syntactically correct structures, but they overflow or have unknown values.
 impl TryFrom<ValueExpr> for ElementTypeValue {
     type Error = CompileError;
 
@@ -237,9 +234,9 @@ impl std::fmt::Display for ElementTypeValue {
     }
 }
 
-// These conversions are used when creating OutputStreamMessages as a poor
-// men's serializer (for `name` and `topic` fields). Probably want to make
-// a more structural solution.
+/// These conversions are used when creating `OutputStreamMessages` as a poor
+/// men's serializer (for `name` and `topic` fields). Probably want to make
+/// a more structural solution.
 impl From<&ElementTypeValue> for String {
     fn from(value: &ElementTypeValue) -> String {
         match value {
@@ -264,9 +261,8 @@ impl From<&ElementTypeValue> for ShortString {
 
 //------------ List type ----------------------------------------------------
 
-// A recursive, materialized list that can contain any TypeValue variant,
-// including Records and Lists.
-
+/// A recursive, materialized list that can contain any [`TypeValue`] variant,
+/// including Records and Lists.
 #[derive(Debug, Eq, Clone, Hash, PartialEq, Serialize)]
 pub struct List(pub(crate) Vec<ElementTypeValue>);
 
@@ -297,10 +293,10 @@ impl List {
         todo!()
     }
 
-    // Get a reference to a field on a List, indicated by the first index in
-    // the field index, and then descent into that field, based on the
-    // following indexes in the field_index. Returns None if the field index
-    // is empty.
+    /// Get a reference to a field on a List, indicated by the first index in
+    /// the field index, and then descent into that field, based on the
+    /// following indexes in the `field_index`. Returns `None` if the field index
+    /// is empty.
     pub fn get_field_by_index(
         &self,
         field_index: FieldIndex,
@@ -325,10 +321,10 @@ impl List {
         elm
     }
 
-    // Get the owned value of a field on a List, indicated by the first index
-    // in the field index, and then descent into that field, based on the
-    // following indexes in the field_index. Returns None if the field index
-    // is empty.
+    /// Get the owned value of a field on a List, indicated by the first index
+    /// in the field index, and then descent into that field, based on the
+    /// following indexes in the field_index. Returns `None` if the field index
+    /// is empty.
     pub fn get_field_by_index_owned(
         &mut self,
         field_index: FieldIndex,
@@ -650,9 +646,8 @@ impl From<ListToken> for usize {
 
 //---------------- Record type ----------------------------------------------
 
-// A recursive, materialized Record type that can contain any TypeValue
-// variant, including Lists and Records.
-
+/// A recursive, materialized Record type that can contain any [`TypeValue`]
+/// variant, including Lists and Records.
 #[derive(Debug, PartialEq, Eq, Default, Clone, Hash)]
 pub struct Record(Vec<(ShortString, ElementTypeValue)>);
 
@@ -664,14 +659,14 @@ impl<'a> Record {
         Self(elems)
     }
 
-    // Sorted inserts on record creation time are essential for the PartialEq
-    // impl (equivalence testing) of a Record TypeDef. The TypeDefs of two
-    // Records are compared field-by-field in a simple zipped loop. Therefore
-    // all the fields need to be sorted in the same way (aligned), otherwise
-    // they'll be unequal, even if all the values are the same. This method
-    // assumes the TypeValues are ordered, and DOES NOT CHECK THE SORTING, but
-    // it does check whether the TypeValue of the record-to-be-created matches
-    // its type definition.
+    /// Sorted inserts on record creation time are essential for the `PartialEq`
+    /// impl (equivalence testing) of a Record TypeDef. The TypeDefs of two
+    /// Records are compared field-by-field in a simple zipped loop. Therefore
+    /// all the fields need to be sorted in the same way (aligned), otherwise
+    /// they'll be unequal, even if all the values are the same. This method
+    /// assumes the TypeValues are ordered, and DOES NOT CHECK THE SORTING, but
+    /// it does check whether the TypeValue of the record-to-be-created matches
+    /// its type definition.
     pub fn create_instance_with_ordered_fields(
         ty: &TypeDef,
         kvs: Vec<(&str, TypeValue)>,
@@ -767,13 +762,13 @@ impl<'a> Record {
         Ok(kvs)
     }
 
-    // This function requires quite the trust from our VM and the user, it
-    // takes a Vec of TypeValues under the assumption that they are exactly
-    // ordered the way the resulting Record is, so that the caller can omit
-    // the field NAMES, only supplying the values. If you have the field
-    // names available you should probably use the
-    // `create_instance_with_ordered_fields` method, which does check whether
-    // field names and type match.
+    /// This function requires quite the trust from our VM and the user, it
+    /// takes a Vec of TypeValues under the assumption that they are exactly
+    /// ordered the way the resulting Record is, so that the caller can omit
+    /// the field NAMES, only supplying the values. If you have the field
+    /// names available you should probably use the
+    /// `create_instance_with_ordered_fields` method, which does check whether
+    /// field names and type match.
     pub fn create_instance_from_ordered_fields(
         ty: &TypeDef,
         mut values: Vec<TypeValue>,
@@ -841,10 +836,10 @@ impl<'a> Record {
             .map(|i| self.0.remove(i).1)
     }
 
-    // Get a reference to a field on a List, indicated by the first index in
-    // the field index, and then descent into that field, based on the
-    // following indexes in the field_index. Returns None if the field index
-    // is empty.
+    /// Get a reference to a field on a List, indicated by the first index in
+    /// the field index, and then descent into that field, based on the
+    /// following indexes in the field_index. Returns None if the field index
+    /// is empty.
     pub fn get_field_by_index(
         &'a self,
         field_index: &FieldIndex,
@@ -861,10 +856,10 @@ impl<'a> Record {
         elm
     }
 
-    // Get a reference to a field on a List, indicated by the first index in
-    // the field index, and then descent into that field, based on the
-    // following indexes in the field_index. Returns None if the field index
-    // is empty.
+    /// Get a reference to a field on a List, indicated by the first index in
+    /// the field index, and then descent into that field, based on the
+    /// following indexes in the field_index. Returns None if the field index
+    /// is empty.
     pub fn get_field_by_index_owned(
         &mut self,
         field_index: FieldIndex,
@@ -1036,8 +1031,8 @@ impl Serialize for Record {
     }
 }
 
-// Value Expressions that contain a Record parsed as a pair of
-// (field_name, value) pairs. This turns it into an actual Record.
+/// Value Expressions that contain a Record parsed as a pair of
+/// `(field_name, value)` pairs. This turns it into an actual Record.
 impl TryFrom<AnonymousRecordValueExpr> for Record {
     type Error = CompileError;
 
@@ -1123,28 +1118,29 @@ impl From<RecordToken> for usize {
 
 //------------ EnumBytesRecord trait ----------------------------------------
 
-// This trait is used for BytesRecord types that are enums themselves,
-// currently that is only the BytesRecord<BmpMessage> type. This allows the
-// roto user to create match patterns for these BytesRecord instances.
-
-// Unlike a normal record, a bytes record need to have its recursive field
-// resolved in one go, there can be no intermediary methods that return a
-// (sub)-field value and then other methods can take that as argument for the
-// next recursion IN THE VM, because that would mean having to clone the
-// (sub-)field and probably the whole bytes message. This would defy the
-// point of lazy evaluation. Therefore this method takes the bytes record AND
-// the complete field index vec to go to do all the recursion in this method.
-// The data-fields of the variants in this enum are handled as closely as
-// possible to actual lazy fields. Note that we're still copying bytes out
-// into the actual variant. TODO.
-
+/// This trait is used for BytesRecord types that are enums themselves,
+/// currently that is only the `BytesRecord<BmpMessage>` type. This allows the
+/// roto user to create match patterns for these BytesRecord instances.
+///
+/// Unlike a normal record, a bytes record need to have its recursive field
+/// resolved in one go, there can be no intermediary methods that return a
+/// (sub)-field value and then other methods can take that as argument for the
+/// next recursion IN THE VM, because that would mean having to clone the
+/// (sub-)field and probably the whole bytes message. This would defy the
+/// point of lazy evaluation. Therefore this method takes the bytes record AND
+/// the complete field index vec to go to do all the recursion in this method.
+/// The data-fields of the variants in this enum are handled as closely as
+/// possible to actual lazy fields. Note that we're still copying bytes out
+/// into the actual variant. TODO.
 pub trait EnumBytesRecord {
     fn get_variant(&self) -> LazyRecordTypeDef;
 
-    // Returns the TypeValue for a variant and field_index on this
-    // bytes_record. Returns a TypeValue::Unknown if the requested
-    // variant does not match the bytes record. Returns an error if
-    // no field_index was specified.
+    /// Returns the [`TypeValue`] for a variant and `field_index`` on this
+    /// `bytes_record`.
+    ///
+    /// Returns a [`TypeValue::Unknown`] if the requested
+    /// variant does not match the bytes record. Returns an error if
+    /// no field_index was specified.
     fn get_field_index_for_variant(
         &self,
         variant_token: LazyRecordTypeDef,
@@ -1165,10 +1161,9 @@ pub trait RecordType: AsRef<[u8]> {
 
 //------------ BytesRecord type ---------------------------------------------
 
-// A wrapper around routecore types, used to store into a TypeValue. The
-// actual mapping between routecore methods and Roto record field names and
-// values does not happen here, but in the LazyRecord type.
-
+/// A wrapper around routecore types, used to store into a [`TypeValue`]. The
+/// actual mapping between routecore methods and Roto record field names and
+/// values does not happen here, but in the [`LazyRecord`]` type.
 #[derive(Debug, Serialize, Clone)]
 pub struct BytesRecord<T: RecordType>(pub T);
 
@@ -1213,11 +1208,10 @@ impl<T: RecordType> std::hash::Hash for BytesRecord<T> {
 
 //------------- LazyElementTypeValue type -----------------------------------
 
-// The containing element of a LazyRecord, besides being able to store
-// recursive and simple collections (like its counterpart the materialized
-// LazyElementTypeValue), it can also host unevaluated expressions (as
-// closures) of field values, to be called by the VM at runtime.
-
+/// The containing element of a [`LazyRecord`], besides being able to store
+/// recursive and simple collections (like its counterpart the materialized
+/// LazyElementTypeValue), it can also host unevaluated expressions (as
+/// closures) of field values, to be called by the VM at runtime.
 #[allow(clippy::type_complexity)]
 pub enum LazyElementTypeValue<'a, T: RecordType> {
     LazyRecord(LazyRecord<'a, T>),
@@ -1342,15 +1336,14 @@ impl<'a, T: RecordType + std::fmt::Debug> LazyElementTypeValue<'a, T> {
 
 //------------ LazyRecord type ----------------------------------------------
 
-// The LazyRecord type is the mapping between the routecore parser methods
-// and the roto record (field_name, value) pairs that we communicate to a
-// roto user. It does contains neither the parser, nor the original bytes of
-// the message, instead each method of LazyRecord requires the caller (the
-// roto VM) to pass in a reference to the BytesRecord. A value whether lazily
-// evaluated or not, can be modified by the caller. The result of the
-// modification should be materialized into a (regular) roto record though,
-// the LazyRecord itself cannot be stored into a TypeValue variant.
-
+/// The [`LazyRecord`] type is the mapping between the routecore parser methods
+/// and the roto record `(field_name, value)` pairs that we communicate to a
+/// roto user. It contains neither the parser, nor the original bytes of
+/// the message, instead each method of [`LazyRecord`] requires the caller (the
+/// roto VM) to pass in a reference to the [`BytesRecord`]. A value whether lazily
+/// evaluated or not, can be modified by the caller. The result of the
+/// modification should be materialized into a (regular) roto record though,
+/// the [`LazyRecord`] itself cannot be stored into a [`TypeValue`] variant.
 #[derive(Debug)]
 pub struct LazyRecord<'a, T: RecordType> {
     value: LazyNamedTypeDef<'a, T>,

--- a/src/types/datasources.rs
+++ b/src/types/datasources.rs
@@ -47,9 +47,9 @@ impl DataSource {
         }
     }
 
-    // methods on a data source can indicate whether they are returning a
-    // value created by the method or a reference to a value in the data
-    // source itself, through the TableMethodValue enum.
+    /// Methods on a data source can indicate whether they are returning a
+    /// value created by the method or a reference to a value in the data
+    /// source itself, through the [`DataSourceMethodValue`] enum.
     pub(crate) fn exec_method(
         &self,
         method_token: usize,
@@ -115,8 +115,8 @@ use super::{
     typevalue::TypeValue,
 };
 
-// This data-structure only exists to populate the static methods for the type
-// `Rib`, e.g. the methods `Rib::method_name()` and their properties.
+/// This data-structure only exists to populate the static methods for the type
+/// `Rib`, e.g. the methods `Rib::method_name()` and their properties.
 #[derive(Debug)]
 pub struct RibType {
     pub(crate) ty: TypeDef,
@@ -188,13 +188,13 @@ impl From<RibToken> for usize {
     }
 }
 
-// Wrapper around a prefix store so that it can be used by Roto as an
-// external source of data. See [DataSource] for further details of
-// how it gets shared.
+/// Wrapper around a prefix store so that it can be used by Roto as an
+/// external source of data. See [`DataSource`] for further details of
+/// how it gets shared.
 pub struct Rib<M: Meta> {
-    // The definition of the Roto type as exposed to Roto scripts.
-    // Doesn't necessarily have to be the Meta-data type that is stored in
-    // the prefix store.
+    /// The definition of the Roto type as exposed to Roto scripts.
+    /// Doesn't necessarily have to be the Meta-data type that is stored in
+    /// the prefix store.
     pub name: ShortString,
     pub ty: TypeDef,
     pub store: rotonda_store::MultiThreadedStore<M>,

--- a/src/types/enum_types.rs
+++ b/src/types/enum_types.rs
@@ -140,10 +140,12 @@ impl From<EnumVariant<u32>> for BuiltinTypeValue {
     }
 }
 
-// Every possible enum type that can is available pre-defined should be
-// registered here. This is used by the evaluator to figure out if the
-// name of the enum type, what variants it has, etc. It's not possible
-// for users to create enums currently (there's no syntax!).
+/// Every possible enum type that can is available pre-defined should be
+/// registered here.
+///
+/// This is used by the evaluator to figure out if the
+/// name of the enum type, what variants it has, etc. It's not possible
+/// for users to create enums currently (there's no syntax!).
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize,
 )]
@@ -165,12 +167,12 @@ impl GlobalEnumTypeDef {
         .iter()
     }
 
-    // This method checks if the supplied variant exists as the name of a
-    // GlobalEnum and returns it as Ok(GlobalEnumTypeDef) OR it returns a vec
-    // with all the GlobalEnumTypeDefs that contain it as the name of a
-    // variant, in the form of Err(Vec<GlobalEnumTypeDef>). If the Vec inside
-    // the Err is empty, than the variant name wasn't found at all. The outer
-    // result will return an Err if for some reason the name of the variant cannot be p
+    /// This method checks if the supplied variant exists as the name of a
+    /// `GlobalEnum` and returns it as `Ok(GlobalEnumTypeDef)` OR it returns a [`Vec`]
+    /// with all the [`GlobalEnumTypeDef`]s that contain it as the name of a
+    /// variant, in the form of `Err(Vec<GlobalEnumTypeDef>)`. If the [`Vec`] inside
+    /// the `Err` is empty, than the variant name wasn't found at all. The outer
+    /// result will return an `Err` if for some reason the name of the variant cannot be p
     pub(crate) fn get_enum_for_variant_as_token(
         variant: &str,
     ) -> Result<GlobalEnumTypeDef, Vec<&GlobalEnumTypeDef>> {
@@ -185,8 +187,8 @@ impl GlobalEnumTypeDef {
         })
     }
 
-    // This is the equivalent for a Lazy Enum of the `get_props_for_field`
-    // method of a Lazy Record.
+    /// This is the equivalent for a Lazy Enum of the `get_props_for_field`
+    /// method of a Lazy Record.
     pub(crate) fn get_props_for_variant(
         &self,
         field: &crate::ast::Identifier,
@@ -200,8 +202,8 @@ impl GlobalEnumTypeDef {
         }
     }
 
-    // This method returns the data field of a Variant of the GlobalEnum that
-    // is represented by self.
+    /// This method returns the data field of a Variant of the GlobalEnum that
+    /// is represented by self.
     pub(crate) fn get_value_for_variant(
         &self,
         variant: &str,
@@ -299,9 +301,9 @@ impl GlobalEnumTypeDef {
         }
     }
 
-    // This method checks if any variant of any enum of any global enum itself
-    // has the name `variant`, if so it creates and returns a symbol, that
-    // may have some arguments.
+    /// This method checks if any variant of any enum of any global enum itself
+    /// has the name `variant`, if so it creates and returns a symbol, that
+    /// may have some arguments.
     pub(crate) fn any_variant_as_symbol(
         variant: &str,
     ) -> Result<symbols::Symbol, AccessReceiverError> {

--- a/src/types/lazyrecord_types.rs
+++ b/src/types/lazyrecord_types.rs
@@ -35,10 +35,10 @@ impl RecordType for BmpMessage {
     }
 }
 
-// This is the complete enumeration of all Lazy Record types available to
-// roto users. Note that this does *NOT* include BgpMessage, which is a
-// BytesRecord, by it's also an Enum, therefore it contains a Lazy Record,
-// but it isn't one itself.
+/// This is the complete enumeration of all Lazy Record types available to
+/// roto users. Note that this does *NOT* include BgpMessage, which is a
+/// [`BytesRecord`], by it's also an Enum, therefore it contains a Lazy Record,
+/// but it isn't one itself.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
 pub enum LazyRecordTypeDef {
     InitiationMessage,

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -401,10 +401,10 @@ macro_rules! scalartype {
     }
 }
 
-// An implementation for a TypeDef variant, that has/is:
-// - a ScalarValue
-// - only has a `set` method
-// - has no type conversions.
+/// An implementation for a TypeDef variant, that has/is:
+/// - a ScalarValue
+/// - only has a `set` method
+/// - has no type conversions.
 #[macro_export]
 macro_rules! minimalscalartype {
     (
@@ -445,12 +445,12 @@ macro_rules! lazyrecord {
     };
 }
 
-// this macro produces a LazyField on a LazyRecord, i.e. a method that will be
-// invoked to retrieve the value for that field. For LazyRecords that are
-// backed by a BytesRecord these methods are parsers and these can fail. If
-// they do so we are NOT erroring out, but instead we return a
-// TypeValue::Unknown. Other LazyFields in the LazyRecord may parse just fine,
-// so we want to be able to keep going here.
+/// this macro produces a LazyField on a LazyRecord, i.e. a method that will be
+/// invoked to retrieve the value for that field. For LazyRecords that are
+/// backed by a BytesRecord these methods are parsers and these can fail. If
+/// they do so we are NOT erroring out, but instead we return a
+/// TypeValue::Unknown. Other LazyFields in the LazyRecord may parse just fine,
+/// so we want to be able to keep going here.
 #[macro_export]
 macro_rules! lazyfield {
     (
@@ -488,12 +488,12 @@ macro_rules! lazyfield {
     )}
 }
 
-// this macro produces a LazyEnum on a LazyRecord, i.e. a method that will be
-// invoked to retrieve the value for that field. For LazyRecords that are
-// backed by a BytesRecord these methods are parsers and these can fail. If
-// they do so we are NOT erroring out, but instead we return a
-// TypeValue::Unknown. Other LazyFields in the LazyRecord may parse just fine,
-// so we want to be able to keep going here.
+/// this macro produces a LazyEnum on a LazyRecord, i.e. a method that will be
+/// invoked to retrieve the value for that field. For LazyRecords that are
+/// backed by a BytesRecord these methods are parsers and these can fail. If
+/// they do so we are NOT erroring out, but instead we return a
+/// TypeValue::Unknown. Other LazyFields in the LazyRecord may parse just fine,
+/// so we want to be able to keep going here.
 #[macro_export]
 macro_rules! lazyenum {
     (
@@ -869,8 +869,8 @@ macro_rules! bytes_record_impl {
     }
 }
 
-// These are two small macros turn the Option<..> returned from first into an
-// appropriate error.
+/// These are two small macros turn the Option<..> returned from first into an
+/// appropriate error.
 #[macro_export]
 macro_rules! first_into_compile_err {
     ( 

--- a/src/types/typedef.rs
+++ b/src/types/typedef.rs
@@ -3,8 +3,6 @@
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 
-// These are all the types the user can create. This enum is used to create
-// `user defined` types.
 use log::{trace, debug};
 use routecore::asn::Asn;
 use routecore::bgp::aspath::{HopPath, OwnedHop as Hop};
@@ -41,18 +39,18 @@ use super::{
     builtin::BuiltinTypeValue, collections::List, typevalue::TypeValue,
 };
 
-// the type definition of the type that's stored in the RIB and the
-// vec of field_indexes that are used in the hash to calculate
-// uniqueness for an entry.
+/// the type definition of the type that's stored in the RIB and the
+/// vec of field_indexes that are used in the hash to calculate
+/// uniqueness for an entry.
 pub type RibTypeDef = (Box<TypeDef>, Option<Vec<FieldIndex>>);
 pub type NamedTypeDef = (ShortString, Box<TypeDef>);
 pub type LazyNamedTypeDef<'a, T> =
     Vec<(ShortString, LazyElementTypeValue<'a, T>)>;
 
-// This struct mainly serves the purpose of making sure that all inner
-// Vec<NamedTypeDef> are being sorted at creation time, so that they
-// are comparable (for equivalence) at all times without the need to
-// ever sort them again.
+/// This struct mainly serves the purpose of making sure that all inner
+/// `Vec<NamedTypeDef>` are being sorted at creation time, so that they
+/// are comparable (for equivalence) at all times without the need to
+/// ever sort them again.
 #[derive(Clone, Debug, Eq, Default, Ord, PartialOrd, Serialize)]
 pub struct RecordTypeDef(Vec<NamedTypeDef>);
 
@@ -70,7 +68,7 @@ impl RecordTypeDef {
         self.0.len()
     }
 
-    // returns the number of all fields in the flattened record type.
+    /// returns the number of all fields in the flattened record type.
     pub(crate) fn recursive_len(&self) -> usize {
         let mut len = self.0.len();
         for field in self.0.iter() {
@@ -87,10 +85,10 @@ impl RecordTypeDef {
     }
 }
 
-// Equivalence of two RecordTypeDefs is defined as the two vectors being
-// completely the same, or the field names being the same. The types
-// of the fields are being left out of the equivalence comparison
-// here! That is the responsibility of the evaluator.
+/// Equivalence of two RecordTypeDefs is defined as the two vectors being
+/// completely the same, or the field names being the same. The types
+/// of the fields are being left out of the equivalence comparison
+/// here! That is the responsibility of the evaluator.
 impl PartialEq for RecordTypeDef {
     fn eq(&self, other: &Self) -> bool {
         if self.0 == other.0 {
@@ -321,9 +319,9 @@ impl TypeDef {
         Ok(TypeDef::Record(type_ident_pairs.into()))
     }
 
-    // compute the number of fields in this typedef, mostly relevant for
-    // records to figure how many values should be popped from the stack for
-    // method calls.
+    /// Compute the number of fields in this typedef, mostly relevant for
+    /// records to figure how many values should be popped from the stack for
+    /// method calls.
     pub fn get_field_num(&self) -> usize {
         match self {
             TypeDef::Record(rec_type) => rec_type.recursive_len(),
@@ -335,9 +333,9 @@ impl TypeDef {
         }
     }
 
-    // this function checks that the `fields` vec describes the fields
-    // present in self. If so it returns the positions in the vec of the
-    // corresponding fields, to serve as the token for each field.
+    /// This function checks that the `fields` vec describes the fields
+    /// present in `self`. If so it returns the positions in the vec of the
+    /// corresponding fields, to serve as the token for each field.
     pub(crate) fn has_fields_chain(
         &self,
         check_fields: &[crate::ast::Identifier],
@@ -490,9 +488,9 @@ impl TypeDef {
         Ok((result_type.0, result_type.1, existing_tv))
     }
 
-    // This does a strict check to see if all the names of the fields and
-    // their types match up. It does not take into account possible type
-    // conversions on fields.
+    /// This does a strict check to see if all the names of the fields and
+    /// their types match up. It does not take into account possible type
+    /// conversions on fields.
     pub(crate) fn _check_record_fields(
         &self,
         fields: &[(ShortString, &TypeValue)],
@@ -707,10 +705,10 @@ impl TypeDef {
         }
     }
 
-    // Calculates the hash over the fields that are referenced in the unique
-    // field indexes vec that lives on the Rib typedef.
-    // If there's no field indexes vec then simply calculate the hash over
-    // the (whole) TypeValue that was passed in.
+    /// Calculates the hash over the fields that are referenced in the unique
+    /// field indexes vec that lives on the `Rib` typedef.
+    /// If there's no field indexes vec then simply calculate the hash over
+    /// the (whole) [`TypeValue`] that was passed in.
     pub fn hash_key_values<'a, H: Hasher>(
         &'a self,
         state: &'a mut H,

--- a/src/types/typevalue.rs
+++ b/src/types/typevalue.rs
@@ -44,29 +44,28 @@ use super::{
 /// These are the actual types that are used in the Roto language. This enum
 /// holds both the type-level information and the value. The collection
 /// variants can hold multiple values recursively, e.g. a List of Records.
-
 #[derive(Debug, Eq, Default, Clone, Serialize)]
 #[serde(untagged)]
 pub enum TypeValue {
-    // All the built-in scalars and vectors
+    /// All the built-in scalars and vectors
     Builtin(BuiltinTypeValue),
-    // An ordered list of one user-defined type
+    /// An ordered list of one user-defined type
     List(List),
-    // A map of (key, value) pairs, where value can be any of the other types.
-    // Always user-defined.
+    /// A map of (key, value) pairs, where value can be any of the other types.
+    /// Always user-defined.
     Record(Record),
     // Enum(Enum),
-    // A Record meant to be handled by an Output stream.
+    /// A Record meant to be handled by an Output stream.
     OutputStreamMessage(Arc<OutputStreamMessage>),
-    // A wrapper around an immutable value that lives in an external
-    // datasource, i.e. a table or a rib
+    /// A wrapper around an immutable value that lives in an external
+    /// datasource, i.e. a table or a rib
     SharedValue(Arc<TypeValue>),
-    // Unknown is NOT EQUAL to empty or unitialized, e.g. it may be the
-    // result of a search. A ternary logic value, if you will.
+    /// Unknown is NOT EQUAL to empty or unitialized, e.g. it may be the
+    /// result of a search. A ternary logic value, if you will.
     Unknown,
-    // Used for LinearMemory only, it's the initial state of all positions
-    // except the first two positions (rx and tx). Taking a typevalue in the
-    // vm runtime, also puts this value in its place.
+    /// Used for LinearMemory only, it's the initial state of all positions
+    /// except the first two positions (rx and tx). Taking a typevalue in the
+    /// vm runtime, also puts this value in its place.
     #[default]
     UnInit,
 }
@@ -192,9 +191,9 @@ impl TypeValue {
         }
     }
 
-    // Return a TypeValue if the memory holds the enum variant specified by
-    // the varian_token. If the memory position holds an enum, but not of the
-    // specified variant, then return TypeValue::Unknown.
+    /// Return a TypeValue if the memory holds the enum variant specified by
+    /// the varian_token. If the memory position holds an enum, but not of the
+    /// specified variant, then return TypeValue::Unknown.
     pub fn get_mp_as_variant_or_unknown(
         &self,
         variant_token: Token,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -804,10 +804,9 @@ impl Display for LinearMemory {
 
 //------------ Command Arguments Stack --------------------------------------
 
-// A stack especially for the arguments to a Command. The Vec that forms the
-// stack is immutable, so that the VM doesn't need to clone the MIR code for
-// each run. A counter keeps track of the current position in the stack.
-
+/// A stack especially for the arguments to a Command. The Vec that forms the
+/// stack is immutable, so that the VM doesn't need to clone the MIR code for
+/// each run. A counter keeps track of the current position in the stack.
 #[derive(Debug)]
 pub(crate) struct CommandArgsStack<'a> {
     args: &'a mut VecDeque<CommandArg>,
@@ -825,15 +824,17 @@ impl<'a> CommandArgsStack<'a> {
         self.args.front()
     }
 
-    // Remove and return the first item, decrement the counter This returns
-    // None if the stack has under flowed.
+    /// Remove and return the first item, decrement the counter
+    ///
+    /// This returns `None` if the stack has under flowed.
     fn pop_front(&mut self) -> Option<CommandArg> {
         self.args_counter.checked_sub(1)?;
         self.args.pop_front()
     }
 
-    // Return the last item and decrement the counter. This returns None if
-    // the stack has under flowed.
+    /// Return the last item and decrement the counter.
+    ///
+    /// This returns `None` if the stack has under flowed.
     fn pop(&mut self) -> Result<&'_ CommandArg, VmError> {
         self.args_counter = self
             .args_counter
@@ -848,7 +849,7 @@ impl<'a> CommandArgsStack<'a> {
         self.args.is_empty()
     }
 
-    // Interpret the last stack entry as a constant value.
+    /// Interpret the last stack entry as a constant value.
     pub(crate) fn take_arg_as_constant(
         &mut self,
     ) -> Result<TypeValue, VmError> {
@@ -862,8 +863,8 @@ impl<'a> CommandArgsStack<'a> {
         }
     }
 
-    // Pop ALL arguments and return the top two. Returns None if the stack
-    // underflows, or if one of the arguments does not exist.
+    /// Pop ALL arguments and return the top two. Returns None if the stack
+    /// underflows, or if one of the arguments does not exist.
     pub(crate) fn pop_2(
         mut self,
     ) -> Result<(&'a CommandArg, &'a CommandArg), VmError> {
@@ -885,8 +886,9 @@ impl<'a> CommandArgsStack<'a> {
         Err(VmError::StackUnderflow)
     }
 
-    // Pop ALL arguments and return the top three arguments, Returns None if
-    // the stack underflows, or if one of the arguments does not exist.
+    /// Pop ALL arguments and return the top three arguments.
+    ///
+    /// Returns None if the stack underflows, or if one of the arguments does not exist.
     pub(crate) fn pop_3(
         mut self,
     ) -> Result<(&'a CommandArg, &'a CommandArg, &'a CommandArg), VmError>
@@ -937,10 +939,9 @@ impl<'a> From<&'a mut VecDeque<CommandArg>> for CommandArgsStack<'a> {
 
 //------------ Argument -----------------------------------------------------
 
-// These are the filter-map-level arguments, they can be compiled in when
-// passed in before compiling (`with_arguments()`), or they can be provided
-// at run-time.
-
+/// These are the filter-map-level arguments, they can be compiled in when
+/// passed in before compiling (`with_arguments()`), or they can be provided
+/// at run-time.
 #[derive(Debug, Clone)]
 pub struct FilterMapArg {
     pub(crate) name: ShortString,
@@ -1163,9 +1164,11 @@ impl std::hash::Hash for FilterMapArgs {
     }
 }
 
-// Computes the has over the mir code and the data sources, that is stored in
-// the built VM. This hash serves the purpose to figure out if a new (mir
-// code,data sources) tuple actually contains meaningful changes.
+/// Computes the has over the mir code and the data sources, that is stored in
+/// the built VM.
+///
+/// This hash serves the purpose to figure out if a new (mir
+/// code,data sources) tuple actually contains meaningful changes.
 pub fn compute_hash(
     mir_code: &[MirBlock],
     data_sources: &[ExtDataSource],
@@ -1178,31 +1181,31 @@ pub fn compute_hash(
 
 //------------ CompiledPrimitiveField ----------------------------------------
 
-// Variable Assignments can be of any these types:
-// 1. literal primitive values: a = “AA”;
-// 2. literal compound values: a = [1,2,3]; a = Msg { prefix: fe80::/24,
-//    peer_ip: fe80::1, comment: “bla” };
-// 3. primitive aliasing a = route.prefix;
-// 4. compound aliasing a = Msg { prefix: route.prefix, peer_ip:
-//    route.peer_ip, comment: “bla”  };
-
-// In the first case we're creating a new value, that we'll have to store in a
-// memory position and create a single entry in the VariablesRefTable. In the
-// second case we can do the same thing, since a memory position can hold a
-// complete literal record, provided all of its fields are literal values (so
-// no computation needed at run time). The third case only needs a single
-// entry in the VariablesRefTable, pointing to a pre-filled memory position.
-// The last case is the hardest, we need to be able to store a series of
-// references to memory positions that can addressed from a single entry in
-// the VariablesRefTable.
-
-// In short:
-// 1. single mem_pos_set + entry in var_ref_table
-// 2. single mem_pos_set + entry in var_ref_table
-// 3. entry in var_ref_table
-// 4. mem_pos_sets + entry in var_ref_table
-
-// This the table that maps the user-defined variables from the 'define'
+/// Variable Assignments can be of any these types:
+/// 1. literal primitive values: `a = “AA”;`
+/// 2. literal compound values:
+///    `a = [1,2,3]; a = Msg { prefix: fe80::/24, peer_ip: fe80::1, comment: “bla” };`
+/// 3. primitive aliasing: `a = route.prefix;`
+/// 4. compound aliasing: `a = Msg { prefix: route.prefix, peer_ip:
+///    route.peer_ip, comment: “bla”  };`
+///
+/// In the first case we're creating a new value, that we'll have to store in a
+/// memory position and create a single entry in the `VariablesRefTable`. In the
+/// second case we can do the same thing, since a memory position can hold a
+/// complete literal record, provided all of its fields are literal values (so
+/// no computation needed at run time). The third case only needs a single
+/// entry in the `VariablesRefTable`, pointing to a pre-filled memory position.
+/// The last case is the hardest, we need to be able to store a series of
+/// references to memory positions that can addressed from a single entry in
+/// the `VariablesRefTable`.
+///
+/// In short:
+/// 1. `single mem_pos_set + entry` in `var_ref_table`
+/// 2. `single mem_pos_set + entry` in `var_ref_table`
+/// 3. `entry` in `var_ref_table`
+/// 4. `mem_pos_sets + entry` in `var_ref_table`
+///
+// This the table that maps the user-defined variables from the `define`
 // section to memory positions in the VM.
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledPrimitiveField {
@@ -1267,10 +1270,10 @@ impl CompiledField {
 
 //------------ CompiledVariable ----------------------------------------------
 
-// This is the data-structure that stores snippets of compiled code (sequences
-// of VM commands) that compute a variable, in a flat, stack-friendly way. For
-// scalar values the length of the of the Vec<CompiledField> will be one, for
-// records it will correspond to the number of fields in that record.
+/// This is the data-structure that stores snippets of compiled code (sequences
+/// of VM commands) that compute a variable, in a flat, stack-friendly way. For
+/// scalar values the length of the of the `Vec<CompiledField>` will be one, for
+/// records it will correspond to the number of fields in that record.
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledVariable(Vec<CompiledField>);
 
@@ -1483,8 +1486,8 @@ impl<
         Ok(unwind_stack)
     }
 
-    // Take a number of elements on the stack and flush the rest, so we'll end
-    // up with an empty stack.
+    /// Take a number of elements on the stack and flush the rest, so we'll end
+    /// up with an empty stack.
     fn _take_resolved_and_flush(
         &'a self,
         elem_num: u32, // number of elements to take
@@ -1532,8 +1535,8 @@ impl<
         Ok(take_vec)
     }
 
-    // Take a number of elements on the stack, leaving the rest of the stack
-    // in place.
+    /// Take a number of elements on the stack, leaving the rest of the stack
+    /// in place.
     fn _take_resolved(
         &'a self,
         elem_num: u32, // number of elements to take
@@ -1589,8 +1592,8 @@ impl<
         Ok(take_vec)
     }
 
-    // Take a number of elements on the stack, leaving the rest of the stack
-    // in place.
+    /// Take a number of elements on the stack, leaving the rest of the stack
+    /// in place.
     fn _take_resolved_as_owned(
         &'a self,
         elem_num: u32, // number of elements to take
@@ -1650,14 +1653,18 @@ impl<
         self.hash_id
     }
 
-    // re-populate the VM with different intermediate code and different data
-    // sources. Note that the MIR and the data sources MUST come from the same
-    // RotoPack. If they are not, then the VM will crash or return arbitrary
-    // results, a.k.a. Undefined Behaviour! THIS IS NOT CHECKED BY THIS
-    // METHOD, ITS ON THE CONSUMER OF THIS METHOD TO GUARANTEE THIS.
-
-    // Returns a bool that indicates whether the MIR and the data sources
-    // where actually replaced.
+    /// Re-populate the VM with different intermediate code and different data
+    /// sources.
+    ///
+    /// Note that the MIR and the data sources MUST come from the same
+    /// [`RotoPack`]. If they are not, then the VM will crash or return arbitrary
+    /// results, a.k.a. Undefined Behaviour! THIS IS NOT CHECKED BY THIS
+    /// METHOD, ITS ON THE CONSUMER OF THIS METHOD TO GUARANTEE THIS.
+    ///
+    /// Returns a bool that indicates whether the MIR and the data sources
+    /// where actually replaced.
+    ///
+    /// [`RotoPack`]: crate::compiler::RotoPack
     pub fn replace_mir_code_and_data_sources(
         &'a mut self,
         mir_code: MB,
@@ -3087,53 +3094,53 @@ impl Display for Command {
 
 #[derive(Debug, Hash, Clone)]
 pub enum CommandArg {
-    // Constant index
+    /// Constant index
     ConstantIndex(TypeValue),
-    // TypeValue constant
+    /// TypeValue constant
     ConstantValue(TypeValue),
-    // Variable with token value
+    /// Variable with token value
     Variable(usize),
-    // extra runtime argument for filter_map & term
+    /// extra runtime argument for filter_map & term
     Argument(usize),
-    // a list that needs to be stored at a memory position
+    /// a list that needs to be stored at a memory position
     List(List),
-    // a record that needs to be stored at a mem position
+    /// a record that needs to be stored at a mem position
     Record(Record),
-    // the placeholder for the value of the rx type at runtime
+    /// the placeholder for the value of the rx type at runtime
     RxValue,
-    // the placeholder for the value of the tx type at runtime
+    /// the placeholder for the value of the tx type at runtime
     TxValue,
-    // method token value
+    /// method token value
     Method(usize),
-    // data source: table token value
+    /// data source: table token value
     DataSourceTable(usize),
-    // data source: rib token value
+    /// data source: rib token value
     DataSourceRib(usize),
-    // output stream value
+    /// output stream value
     OutputStream(usize),
-    // field access token value
+    /// field access token value
     FieldAccess(usize),
-    // field index token value (for LazyRecord)
+    /// field index token value (for LazyRecord)
     FieldIndex(FieldIndex),
-    // builtin method token value
+    /// builtin method token value
     BuiltinMethod(usize),
-    // memory position
+    /// memory position
     MemPos(u32),
-    // type definition
+    /// type definition
     Type(TypeDef),
-    // argument types (for method calls)
+    /// argument types (for method calls)
     Arguments(Vec<TypeDef>),
-    // boolean value (used in cmp opcode)
+    /// boolean value (used in cmp opcode)
     Boolean(bool),
-    // term token value
+    /// term token value
     Term(usize),
-    // compare operation
+    /// compare operation
     CompareOp(ast::CompareOp),
-    // a label with its name (to jump to)
+    /// a label with its name (to jump to)
     Label(ShortString),
-    // argument tell what should happen after
+    /// argument tell what should happen after
     AcceptReject(AcceptReject),
-    // the index of a variant of an enum
+    /// the index of a variant of an enum
     Variant(usize),
 }
 
@@ -3239,45 +3246,45 @@ pub enum OpCode {
     ExecuteDataStoreMethod,
     ExecuteValueMethod,
     ExecuteConsumeValueMethod,
-    // Pop a value from the stack and if it's a LazyRecord or a LazyField on a
-    // LazyRecord.
+    /// Pop a value from the stack and if it's a LazyRecord or a LazyField on a
+    /// LazyRecord.
     LoadLazyFieldValue,
     PopStack,
     PushStack,
     ClearStack,
-    // Assumes the top of the stack is a Vec of type values, and modifies the
-    // value on the top of the stack to the element that is indexed by the
-    // first argument is receives. It will recurse into that element if their
-    // is a next argument, and repeats that until the arguments are exhausted.
+    /// Assumes the top of the stack is a Vec of type values, and modifies the
+    /// value on the top of the stack to the element that is indexed by the
+    /// first argument is receives. It will recurse into that element if their
+    /// is a next argument, and repeats that until the arguments are exhausted.
     StackOffset,
-    // Inspects the top of the stack to see if its value corresponds to the
-    // variant of an enum, passed in as a Variant Token in the arguments of
-    // the command. Pushes the result (the boolean) onto the stack. Does not
-    // pop the enum instance of the stack.
+    /// Inspects the top of the stack to see if its value corresponds to the
+    /// variant of an enum, passed in as a Variant Token in the arguments of
+    /// the command. Pushes the result (the boolean) onto the stack. Does not
+    /// pop the enum instance of the stack.
     StackIsVariant,
     MemPosSet,
-    // Push a user-defined argument to the stack.
+    /// Push a user-defined argument to the stack.
     PushArgToStack,
-    // Conditionally skip to the end ot the MIR block.
+    /// Conditionally skip to the end ot the MIR block.
     SkipToEOB,
-    // Skip to the end of the MIR block if the top of the stack holds a
-    // reference to a boolean value true
+    /// Skip to the end of the MIR block if the top of the stack holds a
+    /// reference to a boolean value true
     CondFalseSkipToEOB,
-    // Skip to the end of the MIR block if the top of the stack holds a
-    // reference to a boolean value false.
+    /// Skip to the end of the MIR block if the top of the stack holds a
+    /// reference to a boolean value false.
     CondTrueSkipToEOB,
-    // Skip to the next label in a MIR block if the top of the stack holds a
-    // reference to a TypeValue::Boolean that is false.
+    /// Skip to the next label in a MIR block if the top of the stack holds a
+    /// reference to a TypeValue::Boolean that is false.
     CondFalseSkipToLabel,
-    // Skip to the next label in a MIR block if the top of the stack holds a
-    // reference to a TypeValue::Unknown. Used to match expression variants.
+    /// Skip to the next label in a MIR block if the top of the stack holds a
+    /// reference to a TypeValue::Unknown. Used to match expression variants.
     CondUnknownSkipToLabel,
-    // Debug Label for terms
+    /// Debug Label for terms
     Label,
     SetRxField,
     SetTxField,
-    // The output stream stack holds indexes to memory positions that contain
-    // messages to be send out.
+    /// The output stream stack holds indexes to memory positions that contain
+    /// messages to be send out.
     PushOutputStreamQueue,
     Exit(AcceptReject),
 }


### PR DESCRIPTION
Using doc comments has a couple of advantages:
- The documentation shows up in rustdoc.
- IDE's show the doc comments on hover.
- Rustdoc can warn when links to items are invalid, which helps with keeping the docs up to date.

Rustdoc works best with this format:
```
/// <one line summary>
///
/// <longer description>
```
Because it will then only show the summary in some places, but I haven't changed all comments to this format and left a lot as is.

I also tried adding backticks and brackets for inline code and links, but I've undoubtedly missed a few places.

In the current version, rustdoc will generate a few warnings because I link to a few private items from public items. I'd have to know more about the internals to fix this properly and the documentation still works.

All documentation can be viewed with
```
cargo doc --document-private-items --open
```