### PR TITLE
Compatibility with latest routecore changes

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -29,6 +29,12 @@ pub struct RotoReport {
     errors: Vec<RotoError>,
 }
 
+impl RotoReport {
+    pub fn errors(&self) -> &[RotoError] {
+        &self.errors
+    }
+}
+
 impl std::fmt::Display for RotoReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ariadne::{Color, Label, Report, ReportKind};

--- a/src/types/builtin/basic_route.rs
+++ b/src/types/builtin/basic_route.rs
@@ -1,6 +1,7 @@
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 
 use chrono::Utc;
@@ -430,6 +431,10 @@ impl RouteContext {
 
     pub fn nlri_status(&self) -> NlriStatus {
         self.nlri_status
+    }
+
+    pub fn update_nlri_status(&mut self, status: NlriStatus) {
+        self.nlri_status = status;
     }
 
     pub fn get_attrs_builder(&self) -> Result<PaMap, VmError> {
@@ -1213,8 +1218,23 @@ impl Provenance {
     //     }
     // }
 
+    pub fn mock() -> Self {
+        Self {
+            timestamp: Utc::now(),
+            connection_id: SocketAddr::V4(std::net::SocketAddrV4::new(Ipv4Addr::from(0), 0)),
+            peer_id: PeerId { addr: "127.0.0.1".parse().unwrap(), asn: 0.into() },
+            peer_bgp_id: routecore::bgp::path_attributes::BgpIdentifier::from([0, 0, 0, 0]),
+            peer_distuingisher: [0, 0, 0, 0, 0, 0, 0, 0],
+            peer_rib_type: PeerRibType::Loc
+        }
+    }
+
     pub fn peer_ip(&self) -> std::net::IpAddr {
         self.peer_id.addr
+    }
+
+    pub fn peer_asn(&self) -> Asn {
+        self.peer_id.asn
     }
 
     pub(crate) fn get_props_for_field(

--- a/src/types/builtin/bmp_message.rs
+++ b/src/types/builtin/bmp_message.rs
@@ -370,9 +370,9 @@ bytes_record_impl!(
         record_field(
             "session_config"; 13,
             field(
-                "has_four_octet_asn"; 14,
+                "four_octet_enabled"; 14,
                 Bool,
-                session_config.has_four_octet_asn
+                session_config.four_octet_enabled
             ),
         ),
     )],

--- a/src/types/builtin/builtin_type_value.rs
+++ b/src/types/builtin/builtin_type_value.rs
@@ -7,7 +7,7 @@ use std::net::IpAddr;
 
 use inetnum::asn::Asn;
 use routecore::bgp::types::PathId;
-use routecore::bgp::types::{AfiSafi, AtomicAggregate, MultiExitDisc, NextHop, Origin};
+use routecore::bgp::types::{AfiSafiType, AtomicAggregate, MultiExitDisc, NextHop, Origin};
 use routecore::bgp::path_attributes::AggregatorInfo;
 use inetnum::addr::Prefix;
 use routecore::bgp::communities::HumanReadableCommunity as Community;
@@ -42,7 +42,7 @@ pub enum BuiltinTypeValue {
     HexLiteral(HexLiteral),           // scalar
     IpAddr(IpAddr),                   // scalar
     Prefix(Prefix),                   // scalar
-    AfiSafi(AfiSafi),                 // scalar
+    AfiSafiType(AfiSafiType),                 // scalar
     PathId(PathId),                   // scalar
     PrefixLength(PrefixLength),       // scalar
     LocalPref(routecore::bgp::types::LocalPref),    // scalar
@@ -94,7 +94,7 @@ impl BuiltinTypeValue {
             BuiltinTypeValue::IntegerLiteral(v) => v.into_type(ty),
             BuiltinTypeValue::StringLiteral(v) => v.into_type(ty),
             BuiltinTypeValue::Prefix(v) => v.into_type(ty),
-            BuiltinTypeValue::AfiSafi(v) => v.into_type(ty),
+            BuiltinTypeValue::AfiSafiType(v) => v.into_type(ty),
             BuiltinTypeValue::PathId(v) => v.into_type(ty),
             BuiltinTypeValue::PrefixLength(v) => v.into_type(ty),
             BuiltinTypeValue::Community(v) => v.into_type(ty),
@@ -194,7 +194,7 @@ impl Display for BuiltinTypeValue {
                 }
                 BuiltinTypeValue::Prefix(v) => write!(f, "{}", v),
                 BuiltinTypeValue::PathId(v) => write!(f, "{}", v),
-                BuiltinTypeValue::AfiSafi(v) => write!(f, "{}", v),
+                BuiltinTypeValue::AfiSafiType(v) => write!(f, "{}", v),
                 BuiltinTypeValue::PrefixLength(v) => {
                     write!(f, "{}", v)
                 }
@@ -286,7 +286,7 @@ impl Display for BuiltinTypeValue {
                     write!(f, "{} (Const U32 Enum Variant)", v.value)
                 }
                 BuiltinTypeValue::Prefix(v) => write!(f, "{} (Prefix)", v),
-                BuiltinTypeValue::AfiSafi(v) => write!(f, "{} (AFI SAFI)", v),
+                BuiltinTypeValue::AfiSafiType(v) => write!(f, "{} (AFI SAFI)", v),
                 BuiltinTypeValue::PathId(v) => write!(f, "{} (Path ID)", v),
                 BuiltinTypeValue::PrefixLength(v) => {
                     write!(f, "{} (Prefix Length)", v)

--- a/src/types/builtin/primitives.rs
+++ b/src/types/builtin/primitives.rs
@@ -29,7 +29,7 @@ use inetnum::addr::Prefix;
 use routecore::bgp::types::PathId;
 use routecore::bgp::path_attributes::AggregatorInfo;
 use routecore::bgp::communities::HumanReadableCommunity as Community;
-use routecore::bgp::types::{AfiSafi, AtomicAggregate, LocalPref, MultiExitDisc, NextHop, Origin};
+use routecore::bgp::types::{AfiSafiType, AtomicAggregate, LocalPref, MultiExitDisc, NextHop, Origin};
 
 //------------ U16 Type -----------------------------------------------------
 
@@ -1076,7 +1076,7 @@ impl TryFrom<&TypeValue> for PrefixLength {
 
 //------------ AfiSafi Type --------------------------------------------------
 
-minimalscalartype!(AfiSafi);
+minimalscalartype!(AfiSafiType);
 
 //------------ PathId Type ---------------------------------------------------
 

--- a/src/types/builtin/route.rs
+++ b/src/types/builtin/route.rs
@@ -142,6 +142,22 @@ impl From<&Ipv6MulticastAddpathNlri> for PrefixNlri {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct PrefixRoute(pub PrefixRouteWs);
 
+impl PrefixRouteWs {
+
+    pub fn no_attributes(&self) -> bool {
+        match self {
+            PrefixRouteWs::Ipv4Unicast(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv4UnicastAddpath(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv6Unicast(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv6UnicastAddpath(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv4Multicast(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv4MulticastAddpath(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv6Multicast(rws) => rws.attributes().is_empty(),
+            PrefixRouteWs::Ipv6MulticastAddpath(rws) => rws.attributes().is_empty(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum FlowSpecNlri<O: Octets> {
     Ipv4FlowSpec(Ipv4FlowSpecNlri<O>),

--- a/src/types/typedef.rs
+++ b/src/types/typedef.rs
@@ -61,7 +61,7 @@ pub type LazyNamedTypeDef<'a, T> =
 pub struct RecordTypeDef(Vec<NamedTypeDef>);
 
 impl RecordTypeDef {
-    pub(crate) fn new(mut named_type_vec: Vec<NamedTypeDef>) -> Self {
+    pub fn new(mut named_type_vec: Vec<NamedTypeDef>) -> Self {
         named_type_vec.sort();
         Self(named_type_vec)
     }

--- a/src/types/typedef.rs
+++ b/src/types/typedef.rs
@@ -15,7 +15,7 @@ use routecore::bgp::path_attributes::AggregatorInfo;
 use routecore::bgp::types::{AtomicAggregate, MultiExitDisc, Origin};
 use routecore::bgp::{
     types::PathId,
-    types::{AfiSafi, LocalPref},
+    types::{AfiSafiType, LocalPref},
 };
 use serde::Serialize;
 
@@ -191,7 +191,7 @@ pub enum TypeDef {
     Bool,
     Prefix,
     PrefixLength, // A u8 prefixes by a /
-    AfiSafi,
+    AfiSafiType,
     PathId,
     IpAddr,
     Asn,
@@ -261,7 +261,7 @@ impl TypeDef {
         HexLiteral(StringLiteral,U8,U32,Community;),
         PrefixLength(StringLiteral,IntegerLiteral,U8,U32;),
         Provenance(StringLiteral;),
-        AfiSafi(StringLiteral;),
+        AfiSafiType(StringLiteral;),
         PeerId(StringLiteral;),
         PeerRibType(StringLiteral;),
         PathId(StringLiteral,IntegerLiteral,U32;),
@@ -706,8 +706,8 @@ impl TypeDef {
             TypeDef::PrefixLength => {
                 PrefixLength::get_props_for_method(self.clone(), method_name)
             }
-            TypeDef::AfiSafi => {
-                AfiSafi::get_props_for_method(self.clone(), method_name)
+            TypeDef::AfiSafiType => {
+                AfiSafiType::get_props_for_method(self.clone(), method_name)
             }
             TypeDef::PathId => {
                 PathId::get_props_for_method(self.clone(), method_name)
@@ -931,7 +931,7 @@ impl std::fmt::Display for TypeDef {
             TypeDef::AsPath => write!(f, "AsPath"),
             TypeDef::Hop => write!(f, "Hop"),
             TypeDef::Prefix => write!(f, "Prefix"),
-            TypeDef::AfiSafi => write!(f, "AFI SAFI"),
+            TypeDef::AfiSafiType => write!(f, "AFI SAFI"),
             TypeDef::PathId => write!(f, "Path ID"),
             TypeDef::U32 => write!(f, "U32"),
             TypeDef::U16 => write!(f, "U16"),
@@ -1169,7 +1169,7 @@ impl TryFrom<crate::ast::TypeIdentifier> for TypeDef {
             "HexLiteral" => Ok(TypeDef::HexLiteral),
             "IpAddress" => Ok(TypeDef::IpAddr),
             "Prefix" => Ok(TypeDef::Prefix),
-            "AfiSafi" => Ok(TypeDef::AfiSafi),
+            "AfiSafiType" => Ok(TypeDef::AfiSafiType),
             "PathId" => Ok(TypeDef::PathId),
             "PrefixLength" => Ok(TypeDef::PrefixLength),
             "LocalPref" => Ok(TypeDef::LocalPref),
@@ -1239,7 +1239,7 @@ impl TryFrom<crate::ast::Identifier> for TypeDef {
             "HexLiteral" => Ok(TypeDef::HexLiteral),
             "IpAddress" => Ok(TypeDef::IpAddr),
             "Prefix" => Ok(TypeDef::Prefix),
-            "AfiSafi" => Ok(TypeDef::AfiSafi),
+            "AfiSafiType" => Ok(TypeDef::AfiSafiType),
             "PathId" => Ok(TypeDef::PathId),
             "PrefixLength" => Ok(TypeDef::PrefixLength),
             "LocalPref" => Ok(TypeDef::LocalPref),
@@ -1311,7 +1311,7 @@ impl From<&BuiltinTypeValue> for TypeDef {
             BuiltinTypeValue::StringLiteral(_) => TypeDef::StringLiteral,
             BuiltinTypeValue::Bool(_) => TypeDef::Bool,
             BuiltinTypeValue::Prefix(_) => TypeDef::Prefix,
-            BuiltinTypeValue::AfiSafi(_) => TypeDef::AfiSafi,
+            BuiltinTypeValue::AfiSafiType(_) => TypeDef::AfiSafiType,
             BuiltinTypeValue::PathId(_) => TypeDef::PathId,
             BuiltinTypeValue::PrefixLength(_) => TypeDef::PrefixLength,
             BuiltinTypeValue::IpAddr(_) => TypeDef::IpAddr,
@@ -1381,7 +1381,7 @@ impl From<BuiltinTypeValue> for TypeDef {
             BuiltinTypeValue::StringLiteral(_) => TypeDef::StringLiteral,
             BuiltinTypeValue::Bool(_) => TypeDef::Bool,
             BuiltinTypeValue::Prefix(_) => TypeDef::Prefix,
-            BuiltinTypeValue::AfiSafi(_) => TypeDef::AfiSafi,
+            BuiltinTypeValue::AfiSafiType(_) => TypeDef::AfiSafiType,
             BuiltinTypeValue::PathId(_) => TypeDef::PathId,
             BuiltinTypeValue::PrefixLength(_) => TypeDef::PrefixLength,
             BuiltinTypeValue::IpAddr(_) => TypeDef::IpAddr,

--- a/src/types/typevalue.rs
+++ b/src/types/typevalue.rs
@@ -14,7 +14,7 @@ use routecore::bgp::nlri::afisafi::{
 };
 use routecore::bgp::types::PathId;
 use routecore::bgp::types::{
-    AfiSafi as AfiSafiType, LocalPref, MultiExitDisc, NextHop, Origin
+    AfiSafiType, LocalPref, MultiExitDisc, NextHop, Origin
 };
 use routecore::bgp::workshop::route::RouteWorkshop;
 use serde::Serialize;
@@ -428,7 +428,7 @@ impl RotoType for TypeValue {
             TypeDef::PrefixLength => {
                 PrefixLength::get_props_for_method(ty, method_name)
             }
-            TypeDef::AfiSafi => {
+            TypeDef::AfiSafiType => {
                 AfiSafiType::get_props_for_method(ty, method_name)
             }
             TypeDef::PathId => PathId::get_props_for_method(ty, method_name),
@@ -507,7 +507,7 @@ impl RotoType for TypeValue {
                 BuiltinTypeValue::Origin(v) => v.into_type(ty),
                 BuiltinTypeValue::Prefix(v) => v.into_type(ty),
                 BuiltinTypeValue::PrefixLength(v) => v.into_type(ty),
-                BuiltinTypeValue::AfiSafi(v) => v.into_type(ty),
+                BuiltinTypeValue::AfiSafiType(v) => v.into_type(ty),
                 BuiltinTypeValue::PathId(v) => v.into_type(ty),
                 BuiltinTypeValue::PrefixRoute(v) => v.into_type(ty),
                 BuiltinTypeValue::FlowSpecRoute(v) => v.into_type(ty),
@@ -731,7 +731,7 @@ impl RotoType for TypeValue {
                 BuiltinTypeValue::Prefix(v) => {
                     v.exec_value_method(method_token, args, res_type)
                 }
-                BuiltinTypeValue::AfiSafi(v) => {
+                BuiltinTypeValue::AfiSafiType(v) => {
                     v.exec_value_method(method_token, args, res_type)
                 }
                 BuiltinTypeValue::PathId(v) => {
@@ -879,7 +879,7 @@ impl RotoType for TypeValue {
                 BuiltinTypeValue::Prefix(v) => {
                     v.exec_consume_value_method(method_token, args, res_type)
                 }
-                BuiltinTypeValue::AfiSafi(v) => {
+                BuiltinTypeValue::AfiSafiType(v) => {
                     v.exec_consume_value_method(method_token, args, res_type)
                 }
                 BuiltinTypeValue::PathId(v) => {

--- a/src/types/typevalue.rs
+++ b/src/types/typevalue.rs
@@ -1539,6 +1539,7 @@ impl From<RouteWorkshop<Ipv6MulticastAddpathNlri>> for TypeValue {
     }
 }
 
+/*
 impl From<RouteWorkshop<Ipv6FlowSpecNlri<bytes::Bytes>>> for TypeValue {
     fn from(value: RouteWorkshop<Ipv6FlowSpecNlri<bytes::Bytes>>) -> Self {
         TypeValue::Builtin(BuiltinTypeValue::FlowSpecRoute(FlowSpecRoute {
@@ -1547,3 +1548,4 @@ impl From<RouteWorkshop<Ipv6FlowSpecNlri<bytes::Bytes>>> for TypeValue {
         }))
     }
 }
+*/


### PR DESCRIPTION
This PR contains several small changes: introducing a new Provenance, adapting to new routecore stuff and some miscellaneous things to make everything compile again.

Note that there are `todo!()`'s here, specifically in `impl RotoType`. Once we've figured out what's next for roto, these can be perhaps discard or should otherwise be properly implemented.

There was some confusing re-exporting (in routecore) and renaming (in roto) going in with regards to `AfiSafi(Type)`. Both that re-export and renaming ('use as' in roto) are now gone, which is where all these changes `AfiSafi` -> `AfiSafiType` come from. This was the only way the compiler wouldn't shout at me, but perhaps this has unwanted user-facing consequences. All those changes are captured in a separate commit for if we wanted to revert it, after all.