### PR TITLE
Store the module data in an arc to simplify a lot of things

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [1.76.0, stable, beta, nightly]
+        rust: [1.80.0, stable, beta, nightly]
 
         # Test with no features, default features ("") and all features.
         # Ordered fewest features to most features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nlnetlabs.nl/projects/routing/rotonda/"
 keywords = ["routing", "bgp"]
 categories = ["network-programming"]
 license = "BSD-3-Clause"
-rust-version = "1.76"
+rust-version = "1.80"
 
 [dependencies]
 # ariadne is set to git because of some unpublished contributions made on

--- a/examples/simple.roto
+++ b/examples/simple.roto
@@ -7,3 +7,7 @@ filter-map main(bla: Bla) {
         }
     }
 }
+
+filter-map just_reject(x: u32) {
+    apply { reject }
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -50,8 +50,9 @@ fn main() -> Result<(), roto::RotoReport> {
                 Verdict::Reject(())
             };
             println!("main({y}) = {res:?}   (expected: {expected:?})");
-        }).join().unwrap();
-
+        })
+        .join()
+        .unwrap();
 
         let res = func2.call(y);
         println!("{res:?}");

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -292,7 +292,7 @@ fn record_with_fields_flipped() {
     let f = p
         .get_function::<(i32,), Verdict<(), ()>>("main")
         .expect("No function found (or mismatched types)")
-        .as_func();
+        .into_func();
 
     for x in 0..100 {
         let expected = if x == 20 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod typechecker;
 pub(crate) mod pipeline;
 pub(crate) mod runtime;
 
+pub use codegen::TypedFunc;
 pub use lower::eval::Memory;
 pub use lower::value::IrValue;
 pub use pipeline::*;

--- a/src/lower/eval.rs
+++ b/src/lower/eval.rs
@@ -545,8 +545,8 @@ fn call_runtime_function(
     func: &RuntimeFunction,
     args: Vec<IrValue>,
 ) -> Option<IrValue> {
-    assert_eq!(func.description.parameter_types.len(), args.len());
-    (func.description.wrapped)(args)
+    assert_eq!(func.description.parameter_types().len(), args.len());
+    (func.description.wrapped())(args)
 }
 
 fn eval_operand<'a>(

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -467,7 +467,7 @@ impl<'r> Lowerer<'r> {
 
                         let ir_func = IrFunction {
                             name: ident.node,
-                            ptr: runtime_func.description.pointer,
+                            ptr: runtime_func.description.pointer(),
                             params,
                             ret: if self.type_info.size_of(&ret) > 0 {
                                 Some(self.lower_type(&ret))
@@ -610,7 +610,7 @@ impl<'r> Lowerer<'r> {
 
                 let ir_func = IrFunction {
                     name: m.node,
-                    ptr: runtime_func.description.pointer,
+                    ptr: runtime_func.description.pointer(),
                     params,
                     ret: if self.type_info.size_of(&ret) > 0 {
                         Some(self.lower_type(&ret))

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -77,7 +77,6 @@ pub struct Parsed {
 
 /// Compiler stage: loaded, parsed and type checked
 pub struct TypeChecked {
-    runtime: Runtime,
     trees: Vec<ast::SyntaxTree>,
     type_infos: Vec<TypeInfo>,
     identifiers: StringInterner<StringBackend>,
@@ -86,7 +85,6 @@ pub struct TypeChecked {
 
 /// Compiler stage: HIR
 pub struct Lowered {
-    runtime: Runtime,
     pub ir: Vec<ir::Function>,
     runtime_functions: HashMap<String, IrFunction>,
     identifiers: StringInterner<StringBackend>,
@@ -95,7 +93,6 @@ pub struct Lowered {
 }
 
 pub struct Compiled {
-    runtime: Runtime,
     module: Module,
     identifiers: StringInterner<StringBackend>,
 }
@@ -370,7 +367,6 @@ impl Parsed {
 
         if errors.is_empty() {
             Ok(TypeChecked {
-                runtime,
                 trees,
                 type_infos,
                 identifiers,
@@ -389,7 +385,6 @@ impl Parsed {
 impl TypeChecked {
     pub fn lower(self) -> Lowered {
         let TypeChecked {
-            runtime,
             trees,
             mut type_infos,
             mut identifiers,
@@ -417,7 +412,6 @@ impl TypeChecked {
 
         Lowered {
             ir,
-            runtime,
             runtime_functions,
             identifiers,
             label_store,
@@ -444,7 +438,6 @@ impl Lowered {
             self.type_info,
         );
         Compiled {
-            runtime: self.runtime,
             module,
             identifiers: self.identifiers,
         }
@@ -456,10 +449,6 @@ impl Compiled {
         &mut self,
         name: &str,
     ) -> Result<TypedFunc<Params, Return>, FunctionRetrievalError> {
-        self.module.get_function(
-            &mut self.runtime.type_registry,
-            &self.identifiers,
-            name,
-        )
+        self.module.get_function(&self.identifiers, name)
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -452,11 +452,10 @@ impl Lowered {
 }
 
 impl Compiled {
-    pub fn get_function<'program, Params: RotoParams, Return: Reflect>(
-        &'program mut self,
+    pub fn get_function<Params: RotoParams, Return: Reflect>(
+        &mut self,
         name: &str,
-    ) -> Result<TypedFunc<'program, Params, Return>, FunctionRetrievalError>
-    {
+    ) -> Result<TypedFunc<Params, Return>, FunctionRetrievalError> {
         self.module.get_function(
             &mut self.runtime.type_registry,
             &self.identifiers,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -203,7 +203,7 @@ impl Runtime {
         let description = f.to_function_description(self).unwrap();
         self.check_description(&description)?;
 
-        let Some(first) = description.parameter_types.first() else {
+        let Some(first) = description.parameter_types().first() else {
             panic!()
         };
 
@@ -279,11 +279,11 @@ impl Runtime {
             })
         };
 
-        for ty in &description.parameter_types {
+        for ty in description.parameter_types() {
             check_type(ty)?;
         }
 
-        check_type(&description.return_type)?;
+        check_type(&description.return_type())?;
         Ok(())
     }
 }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -221,7 +221,7 @@ impl TypeChecker<'_> {
             } = func;
 
             let parameter_types: Vec<_> = description
-                .parameter_types
+                .parameter_types()
                 .iter()
                 .map(|ty| {
                     let name = &runtime.get_runtime_type(*ty).unwrap().name;
@@ -232,7 +232,7 @@ impl TypeChecker<'_> {
                 .collect();
 
             let ret_name = &runtime
-                .get_runtime_type(description.return_type)
+                .get_runtime_type(description.return_type())
                 .unwrap()
                 .name;
             let ret_name =


### PR DESCRIPTION
This PR does a couple of things:
1. The data of compiled functions is now freed when it is no longer being used.
2. Each TypedFunc now contains an Arc to that data to prevent it from being dropped too early.
3. This removes the lifetime parameter from TypedFunc.
4. Additionally, it allows us to get multiple functions from a single Roto file.
5. Finally, TypedFunc can now be cloned!

Yay for usability at the cost of some dirty code inside. 