### PR TITLE
Move from `string_interner` to `symbol_table`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ env_logger = "0.10"
 log = "0.4"
 logos = "0.14.0"
 inetnum = "0.1.0"
-string-interner = "0.17.0"
+symbol_table = { version = "0.3.0", features = ["global"] }
 
 [dev-dependencies]
 bytes = "1"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,8 +3,10 @@
 //! A [`SyntaxTree`] is the output of the Roto parser. It contains a
 //! representation of the Roto script as Rust types for further processing.
 
+use std::fmt::Display;
+
 use inetnum::asn::Asn;
-use string_interner::symbol::SymbolU32;
+use symbol_table::GlobalSymbol;
 
 use crate::parser::meta::Meta;
 
@@ -208,7 +210,37 @@ pub struct OutputStream {
 /// It is a word composed of a leading alphabetic Unicode character, followed
 /// by alphanumeric Unicode characters or underscore or hyphen.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Identifier(pub SymbolU32);
+pub struct Identifier(GlobalSymbol);
+
+impl Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Identifier {
+    pub fn as_str(&self) -> &'static str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for Identifier {
+    fn from(value: &str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&String> for Identifier {
+    fn from(value: &String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<String> for Identifier {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct RecordType {

--- a/src/lower/eval.rs
+++ b/src/lower/eval.rs
@@ -14,7 +14,6 @@ use crate::{
     runtime::RuntimeFunction,
 };
 use std::collections::HashMap;
-use string_interner::{backend::StringBackend, StringInterner};
 
 /// Memory for the IR evaluation
 ///
@@ -232,9 +231,8 @@ pub fn eval(
     filter_map: &str,
     mem: &mut Memory,
     rx: Vec<IrValue>,
-    identifiers: &StringInterner<StringBackend>,
 ) -> Option<IrValue> {
-    let filter_map_ident = Identifier(identifiers.get(filter_map).unwrap());
+    let filter_map_ident = Identifier::from(filter_map);
     let f = p
         .iter()
         .find(|f| f.name == filter_map_ident)

--- a/src/lower/ir.rs
+++ b/src/lower/ir.rs
@@ -25,8 +25,6 @@
 
 use std::fmt::Display;
 
-use string_interner::{backend::StringBackend, StringInterner};
-
 use crate::{
     ast::Identifier,
     runtime,
@@ -278,17 +276,16 @@ pub struct Block {
 
 pub struct IrPrinter<'a> {
     pub scope_graph: &'a ScopeGraph,
-    pub identifiers: &'a StringInterner<StringBackend>,
     pub label_store: &'a LabelStore,
 }
 
 impl<'a> IrPrinter<'a> {
     pub fn ident(&self, ident: &Identifier) -> &'a str {
-        self.identifiers.resolve(ident.0).unwrap()
+        ident.as_str()
     }
 
     pub fn scope(&self, scope: ScopeRef) -> String {
-        self.scope_graph.print_scope(scope, self.identifiers)
+        self.scope_graph.print_scope(scope)
     }
 
     pub fn var(&self, var: &Var) -> String {

--- a/src/lower/match_expr.rs
+++ b/src/lower/match_expr.rs
@@ -112,15 +112,13 @@ impl Lowerer<'_> {
         };
 
         let current_label = self.current_label();
-        let lbl_prefix = self.label_store.wrap_internal(
-            current_label,
-            Identifier(self.identifiers.get_or_intern("match")),
-        );
+        let lbl_prefix = self
+            .label_store
+            .wrap_internal(current_label, Identifier::from("match"));
 
-        let default_lbl = self.label_store.wrap_internal(
-            lbl_prefix,
-            Identifier(self.identifiers.get_or_intern("default")),
-        );
+        let default_lbl = self
+            .label_store
+            .wrap_internal(lbl_prefix, Identifier::from("default"));
         let continue_lbl = self.label_store.next(current_label);
 
         // First collect all the information needed to create the switches
@@ -148,9 +146,7 @@ impl Lowerer<'_> {
             .iter()
             .filter_map(|(d, _, _)| *d)
             .map(|d| {
-                let ident = Identifier(
-                    self.identifiers.get_or_intern(format!("case_{d}")),
-                );
+                let ident = Identifier::from(&format!("case_{d}"));
                 let lbl = self.label_store.wrap_internal(lbl_prefix, ident);
                 (d, lbl)
             })
@@ -187,7 +183,7 @@ impl Lowerer<'_> {
             .iter()
             .map(|(_, _, idx)| {
                 let s = format!("arm_{idx}");
-                let ident = Identifier(self.identifiers.get_or_intern(s));
+                let ident = Identifier::from(s);
                 (*idx, self.label_store.wrap_internal(lbl_prefix, ident))
             })
             .collect();
@@ -244,7 +240,7 @@ impl Lowerer<'_> {
     ) {
         self.new_block(lbl);
 
-        let ident = Identifier(self.identifiers.get_or_intern("guard_0"));
+        let ident = Identifier::from("guard_0");
         let guard_lbl = self.label_store.wrap_internal(lbl, ident);
         self.add(Instruction::Jump(guard_lbl));
 
@@ -279,9 +275,7 @@ impl Lowerer<'_> {
                 });
             }
 
-            let ident = Identifier(
-                self.identifiers.get_or_intern(format!("guard_{}", i + 1)),
-            );
+            let ident = Identifier::from(format!("guard_{}", i + 1));
             next_lbl = self.label_store.wrap_internal(lbl, ident);
 
             let arm_label = arm_labels[arm_index];

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -431,8 +431,7 @@ impl<'source> Parser<'source, '_> {
             let variant = self.identifier()?;
             let mut span = self.get_span(&variant);
 
-            let resolved_variant =
-                self.identifiers.resolve(variant.0).unwrap();
+            let resolved_variant = variant.as_str();
 
             let pattern = if resolved_variant == "_" {
                 Pattern::Underscore

--- a/src/parser/test_expressions.rs
+++ b/src/parser/test_expressions.rs
@@ -1,5 +1,3 @@
-use string_interner::StringInterner;
-
 use crate::{ast::Expr, parser::Parser};
 
 use super::{
@@ -9,8 +7,7 @@ use super::{
 
 fn parse_expr(s: &str) -> ParseResult<Meta<Expr>> {
     let mut spans = Spans::default();
-    let mut identifiers = StringInterner::default();
-    Parser::run_parser(Parser::expr, 0, &mut identifiers, &mut spans, s)
+    Parser::run_parser(Parser::expr, 0, &mut spans, s)
 }
 
 #[test]

--- a/src/parser/test_sections.rs
+++ b/src/parser/test_sections.rs
@@ -1,13 +1,10 @@
-use string_interner::StringInterner;
-
 use crate::{ast::Declaration, parser::Parser};
 
 use super::{meta::Spans, ParseResult};
 
 fn parse_function(s: &str) -> ParseResult<Declaration> {
     let mut spans = Spans::default();
-    let mut identifiers = StringInterner::default();
-    Parser::run_parser(Parser::root, 0, &mut identifiers, &mut spans, s)
+    Parser::run_parser(Parser::root, 0, &mut spans, s)
 }
 
 #[test]

--- a/src/typechecker/error.rs
+++ b/src/typechecker/error.rs
@@ -5,10 +5,7 @@ use crate::{
     parser::meta::{Meta, MetaId},
 };
 
-use super::{
-    types::{type_to_string, Type},
-    TypeChecker,
-};
+use super::{types::Type, TypeChecker};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Level {
@@ -86,10 +83,7 @@ impl TypeChecker<'_> {
 
     pub fn error_undeclared_type(&self, ty: &Meta<Identifier>) -> TypeError {
         TypeError {
-            description: format!(
-                "cannot find type `{}`",
-                self.identifiers.resolve(ty.0).unwrap()
-            ),
+            description: format!("cannot find type `{ty}`",),
             location: ty.id,
             labels: vec![Label::error("not found", ty.id)],
         }
@@ -102,10 +96,8 @@ impl TypeChecker<'_> {
         duplicate: impl IntoIterator<Item = &'a Meta<Identifier>>,
         missing: impl IntoIterator<Item = Identifier>,
     ) -> TypeError {
-        let missing: Vec<_> = missing
-            .into_iter()
-            .map(|m| self.identifiers.resolve(m.0).unwrap())
-            .collect();
+        let missing: Vec<_> =
+            missing.into_iter().map(|m| m.as_str()).collect();
 
         let description = if missing.len() > 1 {
             let fields = join_quoted(missing);
@@ -142,12 +134,9 @@ impl TypeChecker<'_> {
         &self,
         type_name: &Meta<Identifier>,
     ) -> TypeError {
-        dbg!(self.identifiers.get("u8"));
-        dbg!(self.identifiers.get("Foo"));
-        let name = self.identifiers.resolve(type_name.0).unwrap();
         TypeError {
             description: format!(
-                "type `{name}` is a built-in type and cannot be overwritten"
+                "type `{type_name}` is a built-in type and cannot be overwritten"
             ),
             location: type_name.id,
             labels: vec![Label::error("declared here", type_name.id)],
@@ -159,9 +148,10 @@ impl TypeChecker<'_> {
         new_declaration: &Meta<Identifier>,
         old_declaration: MetaId,
     ) -> TypeError {
-        let new = self.identifiers.resolve(new_declaration.0).unwrap();
         TypeError {
-            description: format!("type `{new}` is declared multiple times"),
+            description: format!(
+                "type `{new_declaration}` is declared multiple times"
+            ),
             location: new_declaration.id,
             labels: vec![
                 Label::error("cannot overwrite type", new_declaration.id),
@@ -171,9 +161,8 @@ impl TypeChecker<'_> {
     }
 
     pub fn error_not_defined(&self, ident: &Meta<Identifier>) -> TypeError {
-        let s = self.identifiers.resolve(ident.0).unwrap();
         TypeError {
-            description: format!("cannot find value `{s}` in this scope"),
+            description: format!("cannot find value `{ident}` in this scope"),
             location: ident.id,
             labels: vec![Label::error("not found in this scope", ident.id)],
         }
@@ -186,10 +175,9 @@ impl TypeChecker<'_> {
         takes: usize,
         given: usize,
     ) -> TypeError {
-        let name = self.identifiers.resolve(method_name.0).unwrap();
         TypeError {
             description: format!(
-                "{call_type} `{name}` takes {takes} arguments but {given} arguments were given"
+                "{call_type} `{method_name}` takes {takes} arguments but {given} arguments were given"
             ),
             location: method_name.id,
             labels: vec![Label::error(
@@ -206,16 +194,12 @@ impl TypeChecker<'_> {
     ) -> TypeError {
         TypeError {
             description: format!(
-                "cannot match on the type `{}`, \
+                "cannot match on the type `{ty}`, \
                 because only matching on enums is supported.",
-                type_to_string(self.identifiers, ty)
             ),
             location: span,
             labels: vec![Label::error(
-                format!(
-                    "cannot match on type `{}`",
-                    type_to_string(self.identifiers, ty)
-                ),
+                format!("cannot match on type `{ty}`"),
                 span,
             )],
         }
@@ -226,10 +210,8 @@ impl TypeChecker<'_> {
         variant: &Meta<Identifier>,
         ty: &Type,
     ) -> TypeError {
-        let v = self.identifiers.resolve(variant.0).unwrap();
-        let ty = type_to_string(self.identifiers, ty);
         TypeError {
-            description: format!("pattern has a data field, but the variant `{v}` of `{ty}` doesn't have one"),
+            description: format!("pattern has a data field, but the variant `{variant}` of `{ty}` doesn't have one"),
             location: variant.id,
             labels: vec![Label::error("unexpected data field", variant.id)],
         }
@@ -240,10 +222,8 @@ impl TypeChecker<'_> {
         variant: &Meta<Identifier>,
         ty: &Type,
     ) -> TypeError {
-        let v = self.identifiers.resolve(variant.0).unwrap();
-        let ty = type_to_string(self.identifiers, ty);
         TypeError {
-            description: format!("pattern has no data field, but variant `{v}` of `{ty}` does have a data field"),
+            description: format!("pattern has no data field, but variant `{variant}` of `{ty}` does have a data field"),
             location: variant.id,
             labels: vec![Label::error("missing data field", variant.id)],
         }
@@ -254,11 +234,9 @@ impl TypeChecker<'_> {
         variant: &Meta<Identifier>,
         ty: &Type,
     ) -> TypeError {
-        let v = self.identifiers.resolve(variant.0).unwrap();
-        let ty = type_to_string(self.identifiers, ty);
         TypeError {
             description: format!(
-                "the variant `{v}` does not exist on `{ty}`"
+                "the variant `{variant}` does not exist on `{ty}`"
             ),
             location: variant.id,
             labels: vec![Label::error(
@@ -275,8 +253,6 @@ impl TypeChecker<'_> {
         span: MetaId,
         cause: Option<MetaId>,
     ) -> TypeError {
-        let expected = type_to_string(self.identifiers, expected);
-        let got = type_to_string(self.identifiers, got);
         let mut labels = vec![Label::error(
             format!("expected `{expected}`, found `{got}`"),
             span,
@@ -300,10 +276,8 @@ impl TypeChecker<'_> {
         span: MetaId,
         missing_variants: &[Identifier],
     ) -> TypeError {
-        let missing_variants: Vec<_> = missing_variants
-            .iter()
-            .map(|s| self.identifiers.resolve(s.0).unwrap())
-            .collect();
+        let missing_variants: Vec<_> =
+            missing_variants.iter().map(|s| s.as_str()).collect();
 
         TypeError {
             description: format!(

--- a/src/typechecker/scope.rs
+++ b/src/typechecker/scope.rs
@@ -3,8 +3,6 @@ use std::{
     collections::{btree_map::Entry, BTreeMap},
 };
 
-use string_interner::{backend::StringBackend, StringInterner};
-
 use crate::{
     ast::Identifier,
     parser::meta::{Meta, MetaId},
@@ -116,14 +114,13 @@ impl ScopeGraph {
     pub fn print_scope(
         &self,
         mut scope: ScopeRef,
-        identifiers: &StringInterner<StringBackend>,
     ) -> String {
         let mut idents = Vec::new();
         while let Some(idx) = scope.0 {
             let s = &self.scopes[idx];
             let ident = match &s.scope_type {
                 ScopeType::Function(name) => {
-                    identifiers.resolve(name.0).unwrap().to_string()
+                    name.as_str().to_string()
                 }
                 ScopeType::MatchArm(idx, Some(arm)) => {
                     format!("$match_{idx}_arm_{arm}")

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -1,5 +1,3 @@
-use string_interner::{backend::StringBackend, StringInterner};
-
 use crate::{
     ast::Identifier,
     parser::meta::{Meta, MetaId},
@@ -78,66 +76,59 @@ impl Display for Primitive {
     }
 }
 
-pub fn type_to_string(
-    identifiers: &StringInterner<StringBackend>,
-    ty: &Type,
-) -> String {
-    let fmt_args = |args: &[(_, Type)]| {
-        args.iter()
-            .map(|(_, t)| type_to_string(identifiers, t))
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
-    match ty {
-        Type::Var(_) => "{{unknown}}".into(),
-        Type::ExplicitVar(s) => identifiers.resolve(s.0).unwrap().into(),
-        Type::IntVar(_) => "{{integer}}".into(),
-        Type::RecordVar(_, fields) | Type::Record(fields) => format!(
-            "{{ {} }}",
-            fields
-                .iter()
-                .map(|(s, t)| {
-                    format!(
-                        "\"{}\": {}",
-                        identifiers.resolve(s.0).unwrap(),
-                        type_to_string(identifiers, t)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
-        Type::Verdict(a, r) => {
-            format!(
-                "Verdict<{}, {}>",
-                type_to_string(identifiers, a),
-                type_to_string(identifiers, r)
-            )
+impl Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fmt_args = |args: &[(_, Type)]| {
+            use std::fmt::Write;
+            let mut iter = args.into_iter();
+            let mut s = String::new();
+            if let Some((_, i)) = iter.next() {
+                write!(s, "{i}")?;
+            }
+            for (_, i) in iter {
+                write!(s, ", {i}")?;
+            }
+            Ok(s)
+        };
+
+        match self {
+            Type::Var(_) => write!(f, "{{unknown}}"),
+            Type::ExplicitVar(s) => write!(f, "{s}"),
+            Type::IntVar(_) => write!(f, "{{integer}}"),
+            Type::RecordVar(_, fields) | Type::Record(fields) => write!(
+                f,
+                "{{ {} }}",
+                fields
+                    .iter()
+                    .map(|(s, t)| { format!("\"{s}\": {t}") })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Type::Verdict(a, r) => {
+                write!(f, "Verdict<{a}, {r}>",)
+            }
+            Type::Never => write!(f, "!"),
+            Type::Primitive(p) => write!(f, "{p}"),
+            Type::BuiltIn(name, _) => write!(f, " {name}"),
+            Type::List(t) => write!(f, "List<{t}>"),
+            Type::Table(t) => {
+                write!(f, "Table<{t}>")
+            }
+            Type::OutputStream(t) => {
+                write!(f, "OutputStream<{t}>")
+            }
+            Type::Rib(t) => write!(f, "Rib<{t}>"),
+            Type::NamedRecord(x, _) => write!(f, "{x}"),
+            Type::Enum(x, _) => write!(f, "{x}"),
+            Type::Function(args, ret) => {
+                write!(f, "function({}) -> {ret}", fmt_args(args)?)
+            }
+            Type::Filter(args) => write!(f, "filter({})", fmt_args(args)?),
+            Type::FilterMap(args) => {
+                write!(f, "filter-map({})", fmt_args(args)?)
+            }
+            Type::Name(x) => write!(f, "{x}"),
         }
-        Type::Never => "!".into(),
-        Type::Primitive(p) => format!("{p}"),
-        Type::BuiltIn(name, _) => identifiers.resolve(name.0).unwrap().into(),
-        Type::List(t) => format!("List<{}>", type_to_string(identifiers, t)),
-        Type::Table(t) => {
-            format!("Table<{}>", type_to_string(identifiers, t))
-        }
-        Type::OutputStream(t) => {
-            format!("OutputStream<{}>", type_to_string(identifiers, t))
-        }
-        Type::Rib(t) => format!("Rib<{}>", type_to_string(identifiers, t)),
-        Type::NamedRecord(x, _) => identifiers.resolve(x.0).unwrap().into(),
-        Type::Enum(x, _) => identifiers.resolve(x.0).unwrap().into(),
-        Type::Function(args, ret) => {
-            format!(
-                "function({}) -> {}",
-                fmt_args(args),
-                type_to_string(identifiers, ret)
-            )
-        }
-        Type::Filter(args) => format!("filter({})", fmt_args(args)),
-        Type::FilterMap(args) => {
-            format!("filter-map({})", fmt_args(args))
-        }
-        Type::Name(x) => identifiers.resolve(x.0).unwrap().into(),
     }
 }
 
@@ -212,7 +203,6 @@ pub enum FunctionDefinition {
 }
 
 /// A function that can be called from Roto
-///
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Function {
     /// The type signature of this function
@@ -262,12 +252,10 @@ impl Function {
     }
 }
 
-pub fn globals(
-    identifiers: &mut StringInterner<StringBackend>,
-) -> Vec<(Identifier, Type)> {
-    let community = Identifier(identifiers.get_or_intern("Community"));
-    let safi = Identifier(identifiers.get_or_intern("Safi"));
-    let afi = Identifier(identifiers.get_or_intern("Afi"));
+pub fn globals() -> Vec<(Identifier, Type)> {
+    let community = Identifier::from("Community");
+    let safi = Identifier::from("Safi");
+    let afi = Identifier::from("Afi");
 
     [
         ("BLACKHOLE", Type::Name(community)),
@@ -279,14 +267,11 @@ pub fn globals(
         ("VPNV6", Type::Name(afi)),
     ]
     .into_iter()
-    .map(|(s, t)| (Identifier(identifiers.get_or_intern(s)), t))
+    .map(|(s, t)| (Identifier::from(s), t))
     .collect()
 }
 
-pub fn default_types(
-    identifiers: &mut StringInterner<StringBackend>,
-    runtime: &Runtime,
-) -> Vec<(Identifier, Type)> {
+pub fn default_types(runtime: &Runtime) -> Vec<(Identifier, Type)> {
     use Primitive::*;
 
     let primitives = vec![
@@ -307,12 +292,12 @@ pub fn default_types(
     let mut types = Vec::new();
 
     for (n, p) in primitives {
-        let name = Identifier(identifiers.get_or_intern(n));
+        let name = Identifier::from(n);
         types.push((name, Type::Primitive(p)))
     }
 
     for ty in &runtime.runtime_types {
-        let name = Identifier(identifiers.get_or_intern(&ty.name));
+        let name = Identifier::from(&ty.name);
         types.push((name, Type::BuiltIn(name, ty.type_id)))
     }
 
@@ -340,12 +325,11 @@ pub fn default_types(
     for c in compound_types {
         match c {
             Record(n, fields) => {
-                let n = Identifier(identifiers.get_or_intern(n));
+                let n = Identifier::from(n);
                 let fields = fields
                     .iter()
                     .map(|(field_name, field_type)| {
-                        let field_name =
-                            Identifier(identifiers.get_or_intern(field_name));
+                        let field_name = Identifier::from(*field_name);
 
                         // Little hack to get list types for now, until that is in the
                         // actual syntax and we can use a real type parser here.
@@ -358,17 +342,12 @@ pub fn default_types(
                             field_type
                         };
 
-                        let s = Identifier(identifiers.get_or_intern(s));
+                        let s = Identifier::from(s);
 
                         let mut ty = types
                             .iter()
                             .find(|(n, _)| s == *n)
-                            .unwrap_or_else(|| {
-                                panic!(
-                                    "Not found: {}",
-                                    identifiers.resolve(s.0).unwrap()
-                                )
-                            })
+                            .unwrap_or_else(|| panic!("Not found: {s}",))
                             .1
                             .clone();
 
@@ -388,15 +367,13 @@ pub fn default_types(
                 types.push((n, Type::NamedRecord(n, fields)))
             }
             Enum(n, variants) => {
-                let n = Identifier(identifiers.get_or_intern(n));
+                let n = Identifier::from(n);
                 let variants = variants
                     .iter()
                     .map(|(variant_name, v)| {
-                        let variant_name = Identifier(
-                            identifiers.get_or_intern(variant_name),
-                        );
+                        let variant_name = Identifier::from(*variant_name);
                         let v = v.map(|t| {
-                            let t = Identifier(identifiers.get_or_intern(t));
+                            let t = Identifier::from(t);
                             types
                                 .iter()
                                 .find(|(n, _)| t == *n)


### PR DESCRIPTION
This interner is global and doesn't require us to pass an object around, which simplifies the code a lot. Identifiers can therefore just implement `Display`, so we can just print them and things that contain identifiers (AST, types, etc.).