### PR TITLE
Global context

### DIFF
--- a/examples/presentation.rs
+++ b/examples/presentation.rs
@@ -68,7 +68,7 @@ mod hidden {
 use hidden::*;
 
 type Log = *mut OutputStream<Output>;
-type Func = TypedFunc<(Val<Log>, Val<RotondaRoute>), Verdict<(), ()>>;
+type Func = TypedFunc<(), (Val<Log>, Val<RotondaRoute>), Verdict<(), ()>>;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut rt = roto::Runtime::basic()?;
@@ -143,7 +143,7 @@ fn run_with_prefix(
     let mut output = OutputStream::default();
     let log = &mut output as *mut _;
 
-    let verdict = function.call(Val(log), Val(route));
+    let verdict = function.call(&mut (), Val(log), Val(route));
 
     println!("Input: {prefix}");
     println!("Verdict: {verdict:?}");

--- a/examples/runtime.rs
+++ b/examples/runtime.rs
@@ -25,14 +25,14 @@ fn main() -> Result<(), roto::RotoReport> {
         .inspect_err(|e| eprintln!("{e}"))?;
 
     let func = compiled
-        .get_function::<(Val<Bla>,), Verdict<u32, ()>>("main")
+        .get_function::<(), (Val<Bla>,), Verdict<u32, ()>>("main")
         .inspect_err(|e| eprintln!("{e}"))
         .unwrap();
 
     for x in 0..20 {
         let bla = Bla { x };
 
-        let res = func.call(Val(bla));
+        let res = func.call(&mut (), Val(bla));
         let expected = if x > 10 {
             Verdict::Accept(x * 2)
         } else {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,14 +21,14 @@ fn main() -> Result<(), roto::RotoReport> {
         .inspect_err(|e| eprintln!("{e}"))?;
 
     let func = compiled
-        .get_function::<(IpAddr,), Verdict<(), ()>>("main")
+        .get_function::<(), (IpAddr,), Verdict<(), ()>>("main")
         .inspect_err(|e| eprintln!("{e}"))
         .unwrap();
 
-    let res = func.call("0.0.0.0".parse().unwrap());
+    let res = func.call(&mut (), "0.0.0.0".parse().unwrap());
     println!("main(0.0.0.0) = {res:?}");
 
-    let res = func.call("1.1.1.1".parse().unwrap());
+    let res = func.call(&mut (), "1.1.1.1".parse().unwrap());
     println!("main(1.1.1.1) = {res:?}");
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,12 @@ pub use codegen::TypedFunc;
 pub use lower::eval::Memory;
 pub use lower::value::IrValue;
 pub use pipeline::*;
-pub use roto_macros::{roto_function, roto_method, roto_static_method};
+pub use roto_macros::{
+    roto_function, roto_method, roto_static_method, Context,
+};
 pub use runtime::{
-    val::Val, verdict::Verdict, DocumentedFunc, Runtime, RuntimeType,
+    context::{Context, ContextField},
+    val::Val,
+    verdict::Verdict,
+    DocumentedFunc, Runtime, RuntimeType,
 };

--- a/src/lower/match_expr.rs
+++ b/src/lower/match_expr.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use crate::{
     ast::{self, Identifier, Match, Pattern},
     parser::meta::Meta,
-    typechecker::{scope::DefinitionRef, types::Type},
+    typechecker::types::Type,
 };
 
 use super::{
@@ -258,8 +258,8 @@ impl Lowerer<'_> {
             } = &arm.pattern.node
             {
                 let ty = self.type_info.type_of(var);
-                let DefinitionRef(scope, ident) =
-                    self.type_info.resolved_name(var);
+                let (scope, ident) =
+                    self.type_info.resolved_name(var).to_scope_and_name();
 
                 // The offset of the field is (at least) 1 because of the
                 // discriminant.

--- a/src/lower/test_eval.rs
+++ b/src/lower/test_eval.rs
@@ -106,7 +106,12 @@ fn accept() {
     let mut mem = Memory::new();
     let program = compile(s);
     let pointer = mem.allocate(1);
-    program.eval(&mut mem, vec![IrValue::Pointer(pointer), IrValue::U32(0)]);
+    let ctx = IrValue::Pointer(mem.allocate(0));
+    program.eval(
+        &mut mem,
+        ctx,
+        vec![IrValue::Pointer(pointer), IrValue::U32(0)],
+    );
     let res = mem.read_array::<1>(pointer);
     assert_eq!(0, u8::from_ne_bytes(res));
 }
@@ -124,7 +129,8 @@ fn reject() {
     let mut mem = Memory::new();
     let program = compile(s);
     let pointer = mem.allocate(1);
-    program.eval(&mut mem, vec![IrValue::Pointer(pointer)]);
+    let ctx = IrValue::Pointer(mem.allocate(0));
+    program.eval(&mut mem, ctx, vec![IrValue::Pointer(pointer)]);
     let res = mem.read_array::<1>(pointer);
     assert_eq!(1, u8::from_ne_bytes(res));
 }
@@ -147,7 +153,8 @@ fn if_else() {
     let mut mem = Memory::new();
     let program = compile(s);
     let pointer = mem.allocate(1);
-    program.eval(&mut mem, vec![IrValue::Pointer(pointer)]);
+    let ctx = IrValue::Pointer(mem.allocate(0));
+    program.eval(&mut mem, ctx, vec![IrValue::Pointer(pointer)]);
     let res = mem.read_array::<1>(pointer);
     assert_eq!(0, u8::from_ne_bytes(res));
 }
@@ -173,8 +180,12 @@ fn react_to_rx() {
     for i in 0..6 {
         let mut mem = Memory::new();
         let pointer = mem.allocate(1);
-        program
-            .eval(&mut mem, vec![IrValue::Pointer(pointer), IrValue::U32(i)]);
+        let ctx = IrValue::Pointer(mem.allocate(0));
+        program.eval(
+            &mut mem,
+            ctx,
+            vec![IrValue::Pointer(pointer), IrValue::U32(i)],
+        );
         let res = mem.read_array::<1>(pointer);
         assert_eq!(u8::from_ne_bytes(res), (i > 4) as u8, "failed at: {i}");
     }
@@ -203,7 +214,8 @@ fn variable() {
     let mut mem = Memory::new();
     let program = compile(s);
     let pointer = mem.allocate(1);
-    program.eval(&mut mem, vec![IrValue::Pointer(pointer)]);
+    let ctx = IrValue::Pointer(mem.allocate(0));
+    program.eval(&mut mem, ctx, vec![IrValue::Pointer(pointer)]);
     let res = mem.read_array::<1>(pointer);
     assert_eq!(0, u8::from_ne_bytes(res));
 }
@@ -234,8 +246,12 @@ fn calling_function() {
     for x in 0..30 {
         let mut mem = Memory::new();
         let pointer = mem.allocate(1);
-        program
-            .eval(&mut mem, vec![IrValue::Pointer(pointer), IrValue::U32(x)]);
+        let ctx = IrValue::Pointer(mem.allocate(0));
+        program.eval(
+            &mut mem,
+            ctx,
+            vec![IrValue::Pointer(pointer), IrValue::U32(x)],
+        );
         let res = mem.read_array::<1>(pointer);
         assert_eq!(!(10 < x && x < 20) as u8, u8::from_ne_bytes(res));
     }
@@ -267,8 +283,12 @@ fn anonymous_record() {
     for x in 0..30 {
         let mut mem = Memory::new();
         let pointer = mem.allocate(1);
-        program
-            .eval(&mut mem, vec![IrValue::Pointer(pointer), IrValue::U32(x)]);
+        let ctx = IrValue::Pointer(mem.allocate(0));
+        program.eval(
+            &mut mem,
+            ctx,
+            vec![IrValue::Pointer(pointer), IrValue::U32(x)],
+        );
         let res = mem.read_array::<1>(pointer);
         assert_eq!(!(10 < x && x < 20) as u8, u8::from_ne_bytes(res));
     }
@@ -307,8 +327,12 @@ fn typed_record() {
     for x in 0..1 {
         let mut mem = Memory::new();
         let pointer = mem.allocate(1);
-        program
-            .eval(&mut mem, vec![IrValue::Pointer(pointer), IrValue::U32(x)]);
+        let ctx = IrValue::Pointer(mem.allocate(0));
+        program.eval(
+            &mut mem,
+            ctx,
+            vec![IrValue::Pointer(pointer), IrValue::U32(x)],
+        );
         let res = mem.read_array::<1>(pointer);
         assert_eq!(u8::from_ne_bytes(res), !(10 < x && x < 20) as u8);
     }
@@ -342,8 +366,12 @@ fn nested_record() {
     for x in 20..21 {
         let mut mem = Memory::new();
         let pointer = mem.allocate(1);
-        program
-            .eval(&mut mem, vec![IrValue::Pointer(pointer), IrValue::I32(x)]);
+        let ctx = IrValue::Pointer(mem.allocate(0));
+        program.eval(
+            &mut mem,
+            ctx,
+            vec![IrValue::Pointer(pointer), IrValue::I32(x)],
+        );
         let res = mem.read_array::<1>(pointer);
         assert_eq!((x != 20) as u8, u8::from_ne_bytes(res), "for x = {x}");
     }
@@ -377,8 +405,10 @@ fn enum_values() {
         let verdict_pointer = mem.allocate(1);
         let afi_pointer = mem.allocate(1);
         mem.write(afi_pointer, &[variant]);
+        let ctx = IrValue::Pointer(mem.allocate(0));
         program.eval(
             &mut mem,
+            ctx,
             vec![
                 IrValue::Pointer(verdict_pointer),
                 IrValue::Pointer(afi_pointer),
@@ -410,8 +440,10 @@ fn call_runtime_function() {
     for (value, expected) in [(5, 1), (11, 0)] {
         let mut mem = Memory::new();
         let verdict_pointer = mem.allocate(1);
+        let ctx = IrValue::Pointer(mem.allocate(0));
         program.eval(
             &mut mem,
+            ctx,
             vec![IrValue::Pointer(verdict_pointer), IrValue::U32(value)],
         );
         let res = mem.read_array::<1>(verdict_pointer);
@@ -440,8 +472,10 @@ fn ip_addr_method() {
     for (value, expected) in [(5, 1), (6, 0)] {
         let mut mem = Memory::new();
         let verdict_pointer = mem.allocate(1);
+        let ctx = IrValue::Pointer(mem.allocate(0));
         program.eval(
             &mut mem,
+            ctx,
             vec![IrValue::Pointer(verdict_pointer), IrValue::U32(value)],
         );
         let res = mem.read_array::<1>(verdict_pointer);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let settings = Cli::parse();
 
-    let rx = match settings.rx.as_ref().map(AsRef::as_ref) {
+    let args = match settings.rx.as_ref().map(AsRef::as_ref) {
         Some("true") => vec![IrValue::Bool(true)],
         Some("false") => vec![IrValue::Bool(false)],
         Some(x) => vec![IrValue::U32(x.parse().unwrap())],
@@ -24,8 +24,15 @@ fn main() {
     };
 
     let mut mem = Memory::new();
-    let result =
-        roto::run(Runtime::basic().unwrap(), settings.files, &mut mem, rx);
+
+    let ptr = mem.allocate(0);
+    let result = roto::interpret(
+        Runtime::basic().unwrap(),
+        settings.files,
+        &mut mem,
+        IrValue::Pointer(ptr),
+        args,
+    );
     match result {
         Ok(_) => println!("Ok!"),
         Err(e) => eprintln!("{e}"),

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -21,7 +21,7 @@ struct Restrictions {
 }
 
 /// # Parsing value expressions
-impl<'source> Parser<'source, '_> {
+impl Parser<'_, '_> {
     pub fn block(&mut self) -> ParseResult<Meta<Block>> {
         let start = self.take(Token::CurlyLeft)?;
 

--- a/src/parser/filter_map.rs
+++ b/src/parser/filter_map.rs
@@ -5,7 +5,7 @@ use crate::ast::{
 use super::{meta::Meta, token::Token, ParseError, ParseResult, Parser};
 
 /// # Parsing `filter-map` and `filter` sections
-impl<'source> Parser<'source, '_> {
+impl Parser<'_, '_> {
     /// Parse a filter-map or filter expression
     ///
     /// ```ebnf

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -375,7 +375,7 @@ impl<'source, 'spans> Parser<'source, 'spans> {
 }
 
 /// # Parsing identifiers
-impl<'source> Parser<'source, '_> {
+impl Parser<'_, '_> {
     /// Parse an identifier
     ///
     /// The `contains` and `type` keywords are treated as identifiers,
@@ -400,7 +400,7 @@ impl<'source> Parser<'source, '_> {
     }
 }
 
-impl<'source, 'spans> Parser<'source, 'spans> {
+impl Parser<'_, '_> {
     fn add_span<T>(&mut self, span: Span, x: T) -> Meta<T> {
         self.spans.add(span, x)
     }

--- a/src/parser/rib_like.rs
+++ b/src/parser/rib_like.rs
@@ -10,7 +10,7 @@ use crate::ast::{
 };
 
 /// # Rib-like declarations
-impl<'source> Parser<'source, '_> {
+impl Parser<'_, '_> {
     /// Parse a rib declaration
     ///
     /// ```ebnf

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -158,7 +158,7 @@ pub enum Token<'s> {
     Bool(bool),
 }
 
-impl<'source> Display for Token<'source> {
+impl Display for Token<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Token::Ident(s) => s,

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,0 +1,39 @@
+use std::any::{type_name, TypeId};
+
+/// The context or environment that a Roto script runs in
+///
+/// This declares a set of global variables that are initialized just before
+/// the script is run.
+pub trait Context: 'static {
+    /// Return the fields of this struct, their offsets and their types
+    fn fields() -> Vec<ContextField>;
+
+    fn description() -> ContextDescription {
+        ContextDescription {
+            type_id: TypeId::of::<Self>(),
+            type_name: type_name::<Self>(),
+            fields: Self::fields(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ContextDescription {
+    pub type_id: TypeId,
+    pub type_name: &'static str,
+    pub fields: Vec<ContextField>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ContextField {
+    pub name: &'static str,
+    pub offset: usize,
+    pub type_name: &'static str,
+    pub type_id: TypeId,
+}
+
+impl Context for () {
+    fn fields() -> Vec<ContextField> {
+        Vec::new()
+    }
+}

--- a/src/typechecker/expr.rs
+++ b/src/typechecker/expr.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    scope::{ScopeRef, ScopeType},
+    scope::{LocalScopeRef, ScopeType},
     types::{Function, FunctionKind, Primitive, Signature, Type},
     TypeChecker, TypeResult,
 };
@@ -32,7 +32,7 @@ impl Context {
 impl TypeChecker<'_> {
     pub fn block(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         block: &Meta<ast::Block>,
     ) -> TypeResult<bool> {
@@ -79,7 +79,7 @@ impl TypeChecker<'_> {
 
     pub fn expr(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         expr: &Meta<ast::Expr>,
     ) -> TypeResult<bool> {
@@ -490,7 +490,7 @@ impl TypeChecker<'_> {
 
     fn match_expr(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         mat: &Meta<ast::Match>,
     ) -> TypeResult<bool> {
@@ -631,7 +631,7 @@ impl TypeChecker<'_> {
 
     fn binop(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         op: &ast::BinOp,
         span: MetaId,
@@ -780,7 +780,7 @@ impl TypeChecker<'_> {
     fn method_call(
         &mut self,
         _meta_id: MetaId,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         receiver: &Meta<ast::Expr>,
         name: &Meta<Identifier>,
@@ -827,7 +827,7 @@ impl TypeChecker<'_> {
 
     fn static_method_call(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         ty: &Type,
         name: &Meta<Identifier>,
@@ -869,7 +869,7 @@ impl TypeChecker<'_> {
 
     fn check_arguments(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         call_type: &str,
         name: &Meta<Identifier>,
@@ -924,7 +924,7 @@ impl TypeChecker<'_> {
 
     fn record_fields(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         ctx: &Context,
         field_types: Vec<(Meta<Identifier>, Type)>,
         record: &ast::Record,

--- a/src/typechecker/filter_map.rs
+++ b/src/typechecker/filter_map.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{
     expr::Context,
-    scope::{ScopeRef, ScopeType},
+    scope::{LocalScopeRef, ScopeType},
     types::{Primitive, Type},
     TypeChecker, TypeResult,
 };
@@ -13,7 +13,7 @@ use super::{
 impl TypeChecker<'_> {
     pub fn filter_map(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         filter_map: &ast::FilterMap,
     ) -> TypeResult<Type> {
         let ast::FilterMap {
@@ -26,7 +26,9 @@ impl TypeChecker<'_> {
         let scope = self
             .scope_graph
             .wrap(scope, ScopeType::Function(ident.node));
-        self.type_info.function_scopes.insert(ident.id, scope);
+        self.type_info
+            .function_scopes
+            .insert(ident.id, scope.into());
 
         let params = self.params(params)?;
         for (v, t) in &params {
@@ -73,7 +75,7 @@ impl TypeChecker<'_> {
 
     fn define_section(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         define: &[(Meta<Identifier>, Meta<ast::Expr>)],
     ) -> TypeResult<()> {
         for (ident, expr) in define {
@@ -102,7 +104,7 @@ impl TypeChecker<'_> {
 
     pub fn function(
         &mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         function: &ast::FunctionDeclaration,
     ) -> TypeResult<()> {
         let ast::FunctionDeclaration {
@@ -116,7 +118,9 @@ impl TypeChecker<'_> {
             .scope_graph
             .wrap(scope, ScopeType::Function(ident.node));
 
-        self.type_info.function_scopes.insert(ident.id, scope);
+        self.type_info
+            .function_scopes
+            .insert(ident.id, scope.into());
 
         let params = self.params(params)?;
         for (v, t) in &params {

--- a/src/typechecker/scope.rs
+++ b/src/typechecker/scope.rs
@@ -11,35 +11,69 @@ use crate::{
 use super::Type;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct ScopeRef(Option<usize>);
-
-impl ScopeRef {
-    pub const ROOT: Self = Self(None);
+pub enum ScopeRef {
+    Global,
+    Local(LocalScopeRef),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct DefinitionRef(pub ScopeRef, pub Identifier);
+pub struct LocalScopeRef(usize);
+
+impl From<LocalScopeRef> for ScopeRef {
+    fn from(value: LocalScopeRef) -> Self {
+        ScopeRef::Local(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DefinitionRef {
+    Context(Identifier, usize),
+    Constant(Identifier),
+    Local(LocalScopeRef, Identifier),
+}
+
+impl DefinitionRef {
+    pub fn to_scope_and_name(self) -> (ScopeRef, Identifier) {
+        match self {
+            Self::Constant(ident) | Self::Context(ident, _) => {
+                (ScopeRef::Global, ident)
+            }
+            Self::Local(scope, ident) => (ScopeRef::Local(scope), ident),
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct ScopeGraph {
-    globals: BTreeMap<Identifier, Definition>,
+    globals: BTreeMap<Identifier, GlobalDefinition>,
     scopes: Vec<Scope>,
+}
+
+struct GlobalDefinition {
+    ty: Type,
+    kind: GlobalDefinitionKind,
+}
+
+enum GlobalDefinitionKind {
+    Context(usize),
+    Constant,
 }
 
 /// A type checking scope
 struct Scope {
     /// Map from identifier to fully qualified type
-    variables: BTreeMap<Identifier, Definition>,
+    variables: BTreeMap<Identifier, LocalDefinition>,
     scope_type: ScopeType,
     parent: ScopeRef,
 }
 
-struct Definition {
+struct LocalDefinition {
     ty: Type,
     id: MetaId,
 }
 
 pub enum ScopeType {
+    Module(Identifier),
     Function(Identifier),
     MatchArm(usize, Option<usize>),
 }
@@ -51,64 +85,126 @@ impl ScopeGraph {
 
     /// Create a new root scope
     pub fn root(&mut self) -> ScopeRef {
-        ScopeRef::ROOT
+        ScopeRef::Global
     }
 
     /// Create a new scope over `scope`
     pub fn wrap(
         &mut self,
-        parent: ScopeRef,
+        parent: impl Into<ScopeRef>,
         scope_type: ScopeType,
-    ) -> ScopeRef {
+    ) -> LocalScopeRef {
         self.scopes.push(Scope {
             scope_type,
             variables: BTreeMap::new(),
-            parent,
+            parent: parent.into(),
         });
-        ScopeRef(Some(self.scopes.len() - 1))
+        LocalScopeRef(self.scopes.len() - 1)
     }
 
-    pub fn parent(&self, ScopeRef(scope): ScopeRef) -> Option<ScopeRef> {
-        scope.map(|idx| self.scopes[idx].parent)
+    pub fn parent(&self, scope: ScopeRef) -> Option<ScopeRef> {
+        match scope {
+            ScopeRef::Global => None,
+            ScopeRef::Local(LocalScopeRef(idx)) => {
+                Some(self.scopes[idx].parent)
+            }
+        }
     }
 
     pub fn get_var<'a>(
         &'a self,
-        mut scope: ScopeRef,
+        scope: LocalScopeRef,
         identifier: &Meta<Identifier>,
     ) -> Option<(DefinitionRef, &'a Type)> {
-        loop {
-            let variables = match scope.0 {
-                Some(idx) => &self.scopes[idx].variables,
-                None => &self.globals,
-            };
-            if let Some(def) = variables.get(identifier) {
-                return Some((
-                    DefinitionRef(scope, identifier.node),
-                    &def.ty,
-                ));
-            }
+        let mut scope = ScopeRef::Local(scope);
 
+        loop {
+            match scope {
+                ScopeRef::Local(LocalScopeRef(idx)) => {
+                    if let Some(def) =
+                        &self.scopes[idx].variables.get(identifier)
+                    {
+                        return Some((
+                            DefinitionRef::Local(
+                                LocalScopeRef(idx),
+                                identifier.node,
+                            ),
+                            &def.ty,
+                        ));
+                    }
+                }
+                ScopeRef::Global => {
+                    if let Some(def) = self.globals.get(identifier) {
+                        let def_ref = match def.kind {
+                            GlobalDefinitionKind::Context(offset) => {
+                                DefinitionRef::Context(**identifier, offset)
+                            }
+                            GlobalDefinitionKind::Constant => {
+                                DefinitionRef::Constant(**identifier)
+                            }
+                        };
+                        return Some((def_ref, &def.ty));
+                    }
+                }
+            };
             scope = self.parent(scope)?;
+        }
+    }
+
+    pub fn insert_context<'a>(
+        &'a mut self,
+        v: &Meta<Identifier>,
+        ty: impl Borrow<Type>,
+        offset: usize,
+    ) -> Result<(DefinitionRef, &'a Type), ()> {
+        let ty = ty.borrow().clone();
+        match self.globals.entry(v.node) {
+            Entry::Occupied(_) => Err(()),
+            Entry::Vacant(entry) => Ok((
+                DefinitionRef::Constant(**v),
+                &entry
+                    .insert(GlobalDefinition {
+                        ty,
+                        kind: GlobalDefinitionKind::Context(offset),
+                    })
+                    .ty,
+            )),
+        }
+    }
+
+    pub fn insert_global_constant<'a>(
+        &'a mut self,
+        v: &Meta<Identifier>,
+        ty: impl Borrow<Type>,
+    ) -> Result<(DefinitionRef, &'a Type), ()> {
+        let ty = ty.borrow().clone();
+        match self.globals.entry(v.node) {
+            Entry::Occupied(_) => Err(()),
+            Entry::Vacant(entry) => Ok((
+                DefinitionRef::Constant(**v),
+                &entry
+                    .insert(GlobalDefinition {
+                        ty,
+                        kind: GlobalDefinitionKind::Constant,
+                    })
+                    .ty,
+            )),
         }
     }
 
     pub fn insert_var<'a>(
         &'a mut self,
-        scope: ScopeRef,
+        scope: LocalScopeRef,
         v: &Meta<Identifier>,
-        t: impl Borrow<Type>,
+        ty: impl Borrow<Type>,
     ) -> Result<(DefinitionRef, &'a Type), MetaId> {
-        let t = t.borrow().clone();
-        let variables = match scope.0 {
-            Some(idx) => &mut self.scopes[idx].variables,
-            None => &mut self.globals,
-        };
-        match variables.entry(v.node) {
+        let ty = ty.borrow().clone();
+
+        match self.scopes[scope.0].variables.entry(v.node) {
             Entry::Occupied(entry) => Err(entry.get().id),
             Entry::Vacant(entry) => Ok((
-                DefinitionRef(scope, v.node),
-                &entry.insert(Definition { ty: t, id: v.id }).ty,
+                DefinitionRef::Local(scope, v.node),
+                &entry.insert(LocalDefinition { ty, id: v.id }).ty,
             )),
         }
     }
@@ -117,9 +213,10 @@ impl ScopeGraph {
 impl ScopeGraph {
     pub fn print_scope(&self, mut scope: ScopeRef) -> String {
         let mut idents = Vec::new();
-        while let Some(idx) = scope.0 {
-            let s = &self.scopes[idx];
+        while let ScopeRef::Local(s) = scope {
+            let s = &self.scopes[s.0];
             let ident = match &s.scope_type {
+                ScopeType::Module(name) => name.as_str().to_string(),
                 ScopeType::Function(name) => name.as_str().to_string(),
                 ScopeType::MatchArm(idx, Some(arm)) => {
                     format!("$match_{idx}_arm_{arm}")


### PR DESCRIPTION
We wanted to have some implicit global variables that are exposed to the script by the runtime. In contrast with global _constants_, these are defined per invocation and are therefore more flexible. There's a test in here that shows how to use it:

```rust
#[derive(Context)]
struct Ctx {
    pub foo: i32,
    pub bar: bool,
}

let mut rt = Runtime::basic().unwrap();
rt.register_context_type::<Ctx>().unwrap();

let s = src!(
    "
    filter-map main() {
        apply {
            if bar {
                accept foo + 1
            } else {
                accept foo
            } 
        }
    }"
);

let mut p = compile_with_runtime(s, rt);

// Try getting the wrong ctx, which should fail
p.get_function::<(), (), Verdict<i32, ()>>("main")
   .unwrap_err();

// And then with the correct ctx type
let f = p.get_function::<Ctx, (), Verdict<i32, ()>>("main").unwrap();

let mut ctx = Ctx { foo: 9, bar: false };
let output = f.call(&mut ctx);
assert_eq!(output, Verdict::Accept(9));

let mut ctx = Ctx { foo: 10, bar: true };
let output = f.call(&mut ctx);
assert_eq!(output, Verdict::Accept(11));
```

The default context is just `()`, so if no context is defined a `&mut ()` should be passed in.

Under the hood, this is implemented as passing around a single pointer to all functions which refers to the location of the context struct. Note that the context type does not need `#[repr(C)]` or anything like that, because we get the information on the field offsets in that struct from Rust. All the types mentioned in the context type should be registered in Roto though.

There's a couple of things to do in follow-up PRs:
- Add context to rotodoc
- Add context to runtime functions

Also, this could use some more complex tests.
