### PR TITLE
Replace define & apply with let bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roto"
-version.workspace = true 
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true
@@ -38,6 +38,7 @@ rev = "1af294ea2d6c18c5a8fa9b4f272398b7c98e0c48"
 [dev-dependencies]
 bytes = "1"
 routecore = { version = "0.5", features = ["bgp", "bmp", "serde"] }
+tabled = { version = "0.17.0", default-features = false, features = ["std"] }
 
 [profile.profiling]
 inherits = "release"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -46,13 +46,7 @@ pub struct FilterMap {
     pub filter_type: FilterType,
     pub ident: Meta<Identifier>,
     pub params: Meta<Params>,
-    pub body: FilterMapBody,
-}
-
-#[derive(Clone, Debug)]
-pub struct FilterMapBody {
-    pub define: Vec<(Meta<Identifier>, Meta<Expr>)>,
-    pub apply: Meta<Block>,
+    pub block: Meta<Block>,
 }
 
 /// A function declaration, including the [`Block`] forming its definition
@@ -64,11 +58,18 @@ pub struct FunctionDeclaration {
     pub body: Meta<Block>,
 }
 
-/// A block of multiple Roto expressions
+/// A block of multiple statements
 #[derive(Clone, Debug)]
 pub struct Block {
-    pub exprs: Vec<Meta<Expr>>,
+    pub stmts: Vec<Meta<Stmt>>,
     pub last: Option<Box<Meta<Expr>>>,
+}
+
+/// A statement in a block
+#[derive(Clone, Debug)]
+pub enum Stmt {
+    Let(Meta<Identifier>, Meta<Expr>),
+    Expr(Meta<Expr>),
 }
 
 /// A Roto expression

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -42,9 +42,7 @@ fn accept() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                accept
-            }
+            accept
         }
     "
     );
@@ -64,9 +62,7 @@ fn reject() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                reject
-            }
+            reject
         }
     "
     );
@@ -85,12 +81,10 @@ fn equal_to_10() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply {
-                if x == 10 {
-                    accept
-                } else {
-                    reject
-                }
+            if x == 10 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -117,12 +111,10 @@ fn equal_to_10_with_function() {
         }
         
         filter-map main(x: i32) {
-            apply {
-                if is_10(x) {
-                    accept
-                } else {
-                    reject
-                }
+            if is_10(x) {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -153,14 +145,12 @@ fn equal_to_10_with_two_functions() {
         }
 
         filter-map main(x: u32) {
-            apply {
-                if is_10(x) {
-                    accept
-                } else if equals(x, 20) {
-                    accept
-                } else {
-                    reject
-                }
+            if is_10(x) {
+                accept
+            } else if equals(x, 20) {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -182,12 +172,10 @@ fn negation() {
     let s = src!(
         "
         filter-map main(x: i32) {
-            apply {
-                if not (x == 10) {
-                    accept
-                } else {
-                    reject
-                }
+            if not (x == 10) {
+                accept
+            } else {
+                reject
             }
         } 
     "
@@ -214,16 +202,14 @@ fn a_bunch_of_comparisons() {
     let s = src!(
         "
         filter-map main(x: i32) {
-            apply {
-                if (
-                    (x > 10 && x < 20)
-                    || (x >= 30 && x <= 40)
-                    || x == 55
-                ){
-                    accept
-                } else {
-                    reject
-                }
+            if (
+                (x > 10 && x < 20)
+                || (x >= 30 && x <= 40)
+                || x == 55
+            ){
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -255,15 +241,11 @@ fn record() {
         type Foo { a: i32, b: i32 }
 
         filter-map main(x: i32) {
-            define {
-                foo = Foo { a: x, b: 20 };
-            }
-            apply {
-                if foo.a == foo.b {
-                    accept
-                } else {
-                    reject
-                }
+            let foo = Foo { a: x, b: 20 };
+            if foo.a == foo.b {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -292,17 +274,13 @@ fn record_with_fields_flipped() {
         type Foo { a: i32, b: i32 }
 
         filter-map main(x: i32) {
-            define {
-                # These are flipped, to ensure that the order in which
-                # the fields are given doesn't matter:
-                foo = Foo { b: 20, a: x };
-            }
-            apply {
-                if foo.a == foo.b {
-                    accept
-                } else {
-                    reject
-                }
+            # These are flipped, to ensure that the order in which
+            # the fields are given doesn't matter:
+            let foo = Foo { b: 20, a: x };
+            if foo.a == foo.b {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -333,16 +311,12 @@ fn nested_record() {
         type Bar { a: i32, b: i32 }
 
         filter-map main(x: i32) {
-            define {
-                bar = Bar { a: 20, b: x };
-                foo = Foo { x: bar, y: bar };
-            }
-            apply {
-                if foo.x.a == foo.y.b {
-                    accept
-                } else {
-                    reject
-                }
+            let bar = Bar { a: 20, b: x };
+            let foo = Foo { x: bar, y: bar };
+            if foo.x.a == foo.y.b {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -372,15 +346,11 @@ fn misaligned_fields() {
         type Foo { a: i16, b: i32 }
 
         filter-map main(x: i32) {
-            define {
-                foo = Foo { a: 10, b: x };
-            }
-            apply {
-                if foo.b == 20 {
-                    accept
-                } else {
-                    reject
-                }
+            let foo = Foo { a: 10, b: x };
+            if foo.b == 20 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -407,19 +377,14 @@ fn enum_match() {
     let s = src!(
         "
         filter-map main(r: bool) { 
-            define {
-                x = if r {
-                    Afi.IpV4
-                } else {
-                    Afi.IpV6
-                };
-            }
-
-            apply {
-                match x {
-                    IpV4 -> accept,
-                    _ -> reject,
-                }
+            let x = if r {
+                Afi.IpV4
+            } else {
+                Afi.IpV6
+            };
+            match x {
+                IpV4 -> accept,
+                _ -> reject,
             }
         }
     "
@@ -439,12 +404,10 @@ fn arithmetic() {
     let s = src!(
         "
         filter-map main(x: i32) {
-            apply {
-                if x + 10 * 20 < 250 {
-                    accept
-                } else {
-                    reject
-                }
+            if x + 10 * 20 < 250 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -470,12 +433,10 @@ fn call_runtime_function() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply {
-                if pow(x, 2) > 100 {
-                    accept
-                } else {
-                    reject
-                }
+            if pow(x, 2) > 100 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -499,12 +460,10 @@ fn call_runtime_method() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply {
-                if x.is_even() {
-                    accept
-                } else {
-                    reject
-                }
+            if x.is_even() {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -528,9 +487,7 @@ fn int_var() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                accept 32
-            }
+            accept 32
         }
     "
     );
@@ -561,10 +518,8 @@ fn issue_52() {
     let s = src!(
         "
         filter-map main(foo: Foo) {
-            apply {
-                Foo.bar(1);
-                accept
-            }
+            Foo.bar(1);
+            accept
         }
     "
     );
@@ -594,12 +549,10 @@ fn asn() {
     let s = src!(
         "
         filter-map main(x: Asn) {
-            apply {
-                if x == AS1000 {
-                    accept x
-                } else {
-                    reject x
-                }
+            if x == AS1000 {
+                accept x
+            } else {
+                reject x
             }
         }
     "
@@ -625,9 +578,7 @@ fn mismatched_types() {
     let s = src!(
         "
         filter-map main(x: i32) {
-            apply {
-                accept x
-            }
+            accept x
         }
     "
     );
@@ -647,12 +598,10 @@ fn multiply() {
     let s = src!(
         "
         filter-map main(x: u8) {
-            apply {
-                if x > 10 {
-                    accept 2 * x
-                } else {
-                    reject
-                }
+            if x > 10 {
+                accept 2 * x
+            } else {
+                reject
             }
         }
     "
@@ -672,7 +621,7 @@ fn ip_output() {
     let s = src!(
         "
         filter-map main() {
-            apply { accept 1.2.3.4 }
+            accept 1.2.3.4
         }
     "
     );
@@ -692,7 +641,7 @@ fn ip_passthrough() {
     let s = src!(
         "
         filter-map main(x: IpAddr) {
-            apply { accept x }
+            accept x
         }
     "
     );
@@ -712,14 +661,12 @@ fn ipv4_compare() {
     let s = src!(
         "
         filter-map main(x: IpAddr) {
-            apply { 
-                if x == 0.0.0.0 {
-                    accept x
-                } else if x == 192.168.0.0 {
-                    accept x
-                } else {
-                    reject x
-                }
+            if x == 0.0.0.0 {
+                accept x
+            } else if x == 192.168.0.0 {
+                accept x
+            } else {
+                reject x
             }
         }
     "
@@ -751,16 +698,14 @@ fn ipv6_compare() {
     let s = src!(
         "
         filter-map main(x: IpAddr) {
-            apply { 
-                if x == :: {
-                    accept x
-                } else if x == 192.168.0.0 {
-                    accept x
-                } else if x == ::1 {
-                    accept x
-                } else {
-                    reject x
-                }
+            if x == :: {
+                accept x
+            } else if x == 192.168.0.0 {
+                accept x
+            } else if x == ::1 {
+                accept x
+            } else {
+                reject x
             }
         }
     "
@@ -793,9 +738,7 @@ fn construct_prefix() {
     let s = src!(
         "
         filter-map main() {
-            apply { 
-                accept 192.168.0.0 / 16
-            }
+            accept 192.168.0.0 / 16
         }
     "
     );
@@ -819,9 +762,7 @@ fn function_returning_unit() {
     let s = src!(
         "
         filter-map main() {
-            apply { 
-                accept unit_unit()
-            }
+            accept unit_unit()
         }
     "
     );
@@ -872,12 +813,10 @@ fn arc_type() {
     let s = src!(
         "
         filter-map main(choose: bool, x: CloneDrop, y: CloneDrop) {
-            apply { 
-                if choose {
-                    accept x
-                } else {
-                    accept y
-                }
+            if choose {
+                accept x
+            } else {
+                accept y
             }
         }
     "
@@ -910,15 +849,11 @@ fn use_constant() {
     let s = src!(
         "
         filter-map main() {
-            define {
-                safi = 127.0.0.1;
+            let safi = 127.0.0.1;
+            if safi == LOCALHOSTV4 {
+                reject
             }
-            apply {
-                if safi == LOCALHOSTV4 {
-                    reject
-                }
-                accept
-            }
+            accept
         }"
     );
 
@@ -942,13 +877,11 @@ fn use_context() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                if bar {
-                    accept foo + 1
-                } else {
-                    accept foo
-                } 
-            }
+            if bar {
+                accept foo + 1
+            } else {
+                accept foo
+            } 
         }"
     );
 

--- a/src/lower/test_eval.rs
+++ b/src/lower/test_eval.rs
@@ -98,7 +98,7 @@ fn accept() {
     let s = src!(
         "
         filter-map main(msg: u32) {
-            apply { accept }
+            accept
         }
     "
     );
@@ -121,7 +121,7 @@ fn reject() {
     let s = src!(
         "
         filter-map main() {
-            apply { reject }
+            reject
         }
     "
     );
@@ -140,12 +140,10 @@ fn if_else() {
     let s = src!(
         "
         filter-map main() {
-            apply { 
-                if true && true {
-                    accept
-                } else {
-                    reject
-                }
+            if true && true {
+                accept
+            } else {
+                reject
             }
         }      
     "
@@ -164,12 +162,10 @@ fn react_to_rx() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply {
-                if x <= 4 {
-                    accept
-                } else {
-                    reject
-                }
+            if x <= 4 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -196,16 +192,11 @@ fn variable() {
     let s = src!(
         "
     filter-map main() {
-        define {
-            a = 5;
-        }
-
-        apply {
-            if a == 5 {
-                accept
-            } else {
-                reject
-            }
+        let a = 5;
+        if a == 5 {
+            accept
+        } else {
+            reject
         }
     }
     "
@@ -233,10 +224,8 @@ fn calling_function() {
         }
 
         filter-map main(msg: u32) {
-            apply {
-                if small(msg) { accept }
-                reject
-            }
+            if small(msg) { accept }
+            reject
         }
     "
     );
@@ -266,14 +255,9 @@ fn anonymous_record() {
         }
 
         filter-map main(msg: u32) {
-            define {
-                a = { low: 10, high: 20 };
-            }
-
-            apply {
-                if in_range(msg, a.low, a.high) { accept }
-                reject
-            }
+            let a = { low: 10, high: 20 };
+            if in_range(msg, a.low, a.high) { accept }
+            reject
         }
     "
     );
@@ -308,16 +292,11 @@ fn typed_record() {
         }
 
         filter-map main(msg: u32) {
-            define {
-                a = Range { low: 10, high: 20 };
-                b = Range { low: a.low, high: a.high };
-                c = b;
-            }
-
-            apply {
-                if in_range(msg, c) { accept }
-                reject
-            }
+            let a = Range { low: 10, high: 20 };
+            let b = Range { low: a.low, high: a.high };
+            let c = b;
+            if in_range(msg, c) { accept }
+            reject
         }
     "
     );
@@ -346,16 +325,12 @@ fn nested_record() {
         type Bar { a: i32, b: i32 }
 
         filter-map main(x: i32) {
-            define {
-                bar = Bar { a: 20, b: x };
-                foo = Foo { x: bar, y: bar };
-            }
-            apply {
-                if foo.x.a == foo.y.b {
-                    accept
-                } else {
-                    reject
-                }
+            let bar = Bar { a: 20, b: x };
+            let foo = Foo { x: bar, y: bar };
+            if foo.x.a == foo.y.b {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -382,12 +357,10 @@ fn enum_values() {
     let s = src!(
         "
         filter-map main(x: Afi) {
-            apply {
-                if x == Afi.IpV4 {
-                    accept
-                } else {
-                    reject
-                }
+            if x == Afi.IpV4 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -424,12 +397,10 @@ fn call_runtime_function() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply {
-                if pow(x, 2) > 100 {
-                    accept
-                } else {
-                    reject
-                }
+            if pow(x, 2) > 100 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -456,12 +427,10 @@ fn ip_addr_method() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply { 
-                if x.is_even() {
-                    accept
-                } else {
-                    reject
-                }
+            if x.is_even() {
+                accept
+            } else {
+                reject
             }
         }
     "

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -67,12 +67,8 @@ pub enum Token<'s> {
     // === Keywords ===
     #[token("accept")]
     Accept,
-    #[token("apply")]
-    Apply,
     #[token("contains")]
     Contains,
-    #[token("define")]
-    Define,
     #[token("else")]
     Else,
     #[token("exact")]
@@ -89,6 +85,8 @@ pub enum Token<'s> {
     If,
     #[token("in")]
     In,
+    #[token("let")]
+    Let,
     #[token("longer")]
     Longer,
     #[token("match")]
@@ -189,9 +187,7 @@ impl Display for Token<'_> {
             Token::AngleLeft => "<",
             Token::AngleRight => ">",
             Token::Accept => "accept",
-            Token::Apply => "apply",
             Token::Contains => "contains",
-            Token::Define => "define",
             Token::Else => "else",
             Token::Exact => "exact",
             Token::FilterMap => "filter-map",
@@ -200,6 +196,7 @@ impl Display for Token<'_> {
             Token::Import => "import",
             Token::If => "if",
             Token::In => "in",
+            Token::Let => "let",
             Token::Longer => "longer",
             Token::Match => "match",
             Token::Matching => "matching",

--- a/src/typechecker/error.rs
+++ b/src/typechecker/error.rs
@@ -299,9 +299,9 @@ impl TypeChecker<'_> {
         }
     }
 
-    pub fn error_unreachable_expression(
+    pub fn error_unreachable_expression<T>(
         &self,
-        expr: &Meta<Expr>,
+        expr: &Meta<T>,
     ) -> TypeError {
         TypeError {
             description: "expression is unreachable".into(),

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -51,6 +51,7 @@ pub struct TypeChecker<'s> {
     type_info: TypeInfo,
     scope_graph: &'s mut ScopeGraph,
     match_counter: usize,
+    if_else_counter: usize,
 }
 
 pub type TypeResult<T> = Result<T, TypeError>;
@@ -98,6 +99,7 @@ impl TypeChecker<'_> {
             type_info: TypeInfo::new(pointer_bytes),
             scope_graph,
             match_counter: 0,
+            if_else_counter: 0,
         };
 
         let root_scope = checker.scope_graph.root();

--- a/src/typechecker/scope.rs
+++ b/src/typechecker/scope.rs
@@ -73,6 +73,8 @@ struct LocalDefinition {
 }
 
 pub enum ScopeType {
+    Then(usize),
+    Else(usize),
     Module(Identifier),
     Function(Identifier),
     MatchArm(usize, Option<usize>),
@@ -218,6 +220,12 @@ impl ScopeGraph {
             let ident = match &s.scope_type {
                 ScopeType::Module(name) => name.as_str().to_string(),
                 ScopeType::Function(name) => name.as_str().to_string(),
+                ScopeType::Then(idx) => {
+                    format!("$if_{idx}_then")
+                }
+                ScopeType::Else(idx) => {
+                    format!("$if_{idx}_else")
+                }
                 ScopeType::MatchArm(idx, Some(arm)) => {
                     format!("$match_{idx}_arm_{arm}")
                 }

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -815,6 +815,56 @@ fn reference_variable_later_declared() {
 }
 
 #[test]
+fn reference_variable_from_parent_scope() {
+    let s = src!(
+        "
+        filter-map main() {
+            let a = 10;
+            if true {
+                accept a
+            }
+            let b = 20;
+            accept b
+        }
+    "
+    );
+
+    typecheck(s).unwrap();
+}
+
+#[test]
+fn reference_variable_from_child_scope() {
+    let s = src!(
+        "
+        filter-map main() {
+            if true {
+                let a = 10;
+            }
+            let b = a;
+            accept
+        }
+    "
+    );
+
+    typecheck(s).unwrap_err();
+}
+
+#[test]
+fn shadow_variable() {
+    let s = src!(
+        "
+        filter-map main() {
+            let a = 10;
+            let a = a + 1;
+            accept
+        }
+    "
+    );
+
+    typecheck(s).unwrap_err();
+}
+
+#[test]
 fn use_globals() {
     let s = src!(
         "

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -186,13 +186,11 @@ fn filter_map() {
     let s = src!(
         r#"
         filter-map blabla(foo: u32) {
-            define {
-                a = "hello";
-                b = 0.0.0.0/10;
-                c = 192.168.0.0;
-            }
+            let a = "hello";
+            let b = 0.0.0.0/10;
+            let c = 192.168.0.0;
 
-            apply { accept }
+            accept
         }
     "#
     );
@@ -204,12 +202,10 @@ fn filter_map_double_definition() {
     let s = src!(
         r#"
         filter-map blabla(foo: u32) {
-            define {
-                a = "hello";
-                a = 0.0.0.0/10;
-            }
+            let a = "hello";
+            let a = 0.0.0.0/10;
 
-            apply { accept }
+            accept
         }
     "#
     );
@@ -223,11 +219,8 @@ fn using_records() {
         type Foo { a: String }
 
         filter-map bar(r: u32) {
-            define {
-                a = Foo { a: "hello" };
-            }
-
-            apply { accept }
+            let a = Foo { a: "hello" };
+            accept
         }
     "#
     );
@@ -238,11 +231,8 @@ fn using_records() {
         type Foo { a: String }
 
         filter-map bar(r: u32) {
-            define {
-                a = Foo { a: 0.0.0.0 };
-            }
-
-            apply { accept }
+            let a = Foo { a: 0.0.0.0 };
+            accept
         }
     "#
     );
@@ -253,11 +243,8 @@ fn using_records() {
         type Foo { a: string }
 
         filter-map bar(r: u32) {
-            define {
-                a = Foo { };
-            }
-
-            apply { accept }
+            let a = Foo { };
+            accept
         }
     "#
     );
@@ -271,11 +258,8 @@ fn integer_inference() {
         type Foo { x: u8 }
 
         filter-map test(r: u32) {
-            define {
-                foo = Foo { x: 5 };
-            }
-
-            apply { accept }
+            let foo = Foo { x: 5 };
+            accept
         }
     "
     );
@@ -287,12 +271,9 @@ fn integer_inference() {
         type Bar { x: u8 }
 
         filter-map test(r: u32) {
-            define {
-                a = 5;
-                foo = Foo { x: a };
-            }
-
-            apply { accept }
+            let a = 5;
+            let foo = Foo { x: a };
+            accept
         }
     "
     );
@@ -304,13 +285,10 @@ fn integer_inference() {
         type Bar { x: u8 }
 
         filter-map test(r: u32) {
-            define {
-                a = 5;
-                foo = Foo { x: a };
-                bar = Bar { x: a };
-            }
-
-            apply { accept }
+            let a = 5;
+            let foo = Foo { x: a };
+            let bar = Bar { x: a };
+            accept
         }
     "
     );
@@ -322,13 +300,10 @@ fn integer_inference() {
         type Bar { x: u32 }
 
         filter-map test(r: u32) {
-            define {
-                a = 5;
-                foo = Foo { x: a };
-                bar = Bar { x: a };
-            }
-
-            apply { accept }
+            let a = 5;
+            let foo = Foo { x: a };
+            let bar = Bar { x: a };
+            accept
         }
     "
     );
@@ -340,12 +315,9 @@ fn integer_inference() {
         type Bar { x: u32 }
 
         filter-map test(r: u32) {
-            define {
-                foo = Foo { x: 5 };
-                bar = Bar { x: 5 };
-            }
-
-            apply { accept }
+            let foo = Foo { x: 5 };
+            let bar = Bar { x: 5 };
+            accept
         }
     "
     );
@@ -360,12 +332,9 @@ fn assign_field_to_other_record() {
         type Bar { x: u8 }
 
         filter-map test(r: u32) {
-            define {
-                foo = Foo { x: 5 };
-                bar = Bar { x: foo.x };
-            }
-
-            apply { accept }
+            let foo = Foo { x: 5 };
+            let bar = Bar { x: foo.x };
+            accept
         }
     "
     );
@@ -377,12 +346,9 @@ fn assign_field_to_other_record() {
         type Bar { x: u8 }
 
         filter-map test(r: u32) {
-            define {
-                foo = Foo { x: 5 };
-                bar = Bar { x: foo.y };
-            }
-
-            apply { accept }
+            let foo = Foo { x: 5 };
+            let bar = Bar { x: foo.y };
+            accept
         }
     "
     );
@@ -394,12 +360,9 @@ fn assign_field_to_other_record() {
         type Bar { x: u32 }
 
         filter-map test(r: u32) {
-            define {
-                foo = Foo { x: 5 };
-                bar = Bar { x: foo.x };
-            }
-
-            apply { accept }
+            let foo = Foo { x: 5 };
+            let bar = Bar { x: foo.x };
+            accept
         }
     "
     );
@@ -411,12 +374,9 @@ fn ip_addr_method() {
     let s = src!(
         "
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10;
-                is_four = 1 + p.is_ipv4();
-            }
-
-            apply { accept }
+            let p = 10.10.10.10;
+            let is_four = 1 + p.is_ipv4();
+            accept
         }
     "
     );
@@ -425,12 +385,9 @@ fn ip_addr_method() {
     let s = src!(
         "
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10;
-                is_four = true && p.is_ipv4();
-            }
-
-            apply { accept }
+            let p = 10.10.10.10;
+            let is_four = true && p.is_ipv4();
+            accept
         }
     "
     );
@@ -443,12 +400,9 @@ fn ip_addr_method_of_method_return_type() {
     let s = src!(
         "
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10;
-                x = p.to_canonical().is_ipv4();
-            }
-
-            apply { accept }
+            let p = 10.10.10.10;
+            let x = p.to_canonical().is_ipv4();
+            accept
         }
     "
     );
@@ -457,12 +411,9 @@ fn ip_addr_method_of_method_return_type() {
     let s = src!(
         "
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10;
-                x = p.is_ipv4().to_canonical();
-            }
-
-            apply { accept }
+            let p = 10.10.10.10;
+            let x = p.is_ipv4().to_canonical();
+            accept
         }
     "
     );
@@ -475,12 +426,9 @@ fn prefix_method() {
     let s = src!(
         "
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10/20;
-                add = p.address();
-            }
-
-            apply { accept }
+            let p = 10.10.10.10/20;
+            let add = p.address();
+            accept
         }
     "
     );
@@ -497,12 +445,8 @@ fn logical_expr() {
         }
 
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10/10;
-            }
-
-
-            apply { accept }
+            let p = 10.10.10.10/10;
+            accept
         }
     "
     );
@@ -515,11 +459,8 @@ fn logical_expr() {
         }
 
         filter-map test(r: u32) {
-            define {
-                p = 10.10.10.10/10;
-            }
-
-            apply { accept }
+            let p = 10.10.10.10/10;
+            accept
         }
     "#
     );
@@ -542,7 +483,7 @@ fn send_output_stream() {
         }
         
         filter-map test(r: u32) {
-            apply { accept }
+            accept
         }
     "#
     );
@@ -563,7 +504,7 @@ fn send_output_stream() {
         }
 
         filter-map test(r: u32) {
-            apply { accept }
+            accept
         }
     "#
     );
@@ -589,7 +530,7 @@ fn send_output_stream() {
         }
 
         filter-map test(r: u32) {
-            apply { accept }
+            accept
         }
     "#
     );
@@ -615,7 +556,7 @@ fn send_output_stream() {
         }
         
         filter-map test(r: u32) {
-            apply { accept }
+            accept
         }
     "#
     );
@@ -634,14 +575,9 @@ fn record_inference() {
         }
         
         filter-map foo(r: u32) { 
-            define {
-                a = { a: 8 };
-            }
-
-            apply {
-                bar(a);
-                accept
-            }
+            let a = { a: 8 };
+            bar(a);
+            accept
         }
     "
     );
@@ -656,14 +592,9 @@ fn record_inference() {
         }
 
         filter-map foo(r: u32) { 
-            define {
-                a = { b: 8 };
-            }
-
-            apply {
-                bar(a);
-                accept
-            }
+            let a = { b: 8 };
+            bar(a);
+            accept
         }
     "
     );
@@ -678,17 +609,12 @@ fn record_inference() {
         }
         
         filter-map foo(r: u32) { 
-            define {
-                a = { a: 8 };
-                b = A { a: 8 };
+            let a = { a: 8 };
+            let b = A { a: 8 };
+            if bla(a, b) {
+                accept
             }
-
-            apply { 
-                if bla(a, b) {
-                    accept
-                }
-                reject
-            }
+            reject
         }
     "
     );
@@ -704,13 +630,10 @@ fn record_inference() {
         }
 
         filter-map foo(r: u32) { 
-            define {
-                a = { a: 8 };
-                b = A { a: 8 };
-                c = B { a: 8 };
-            }
-
-            apply { accept }
+            let a = { a: 8 };
+            let b = A { a: 8 };
+            let c = B { a: 8 };
+            accept
         }
     "
     );
@@ -726,7 +649,7 @@ fn return_keyword() {
         }
         
         filter-map foo(r: u32) { 
-            apply { accept }
+            accept
         }
     "
     );
@@ -739,7 +662,7 @@ fn return_keyword() {
         }
         
         filter-map foo(r: u32) { 
-            apply { accept }
+            accept
         }
     "
     );
@@ -758,7 +681,7 @@ fn unit_block() {
         }
 
         filter-map foo(r: u32) { 
-            apply { accept }
+            accept
         }
     "
     );
@@ -775,7 +698,7 @@ fn unreachable_expression() {
         }
 
         filter-map foo(r: u32) { 
-            apply { accept }
+            accept
         }
     "
     );
@@ -787,16 +710,11 @@ fn enum_values() {
     let s = src!(
         "
         filter-map main(r: u32) { 
-            define {
-                x = Afi.IpV4;
-            }
-
-            apply {
-                if x == Afi.IpV4 {
-                    accept
-                } else {
-                    reject
-                }
+            let x = Afi.IpV4;
+            if x == Afi.IpV4 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -809,16 +727,11 @@ fn enum_match() {
     let s = src!(
         "
         filter-map foo(r: u32) { 
-            define {
-                x = Afi.IpV4;
-            }
-
-            apply {
-                match x {
-                    IpV4 -> accept,
-                    IpV6 -> accept,
-                    _ -> reject,
-                }
+            let x = Afi.IpV4;
+            match x {
+                IpV4 -> accept,
+                IpV6 -> accept,
+                _ -> reject,
             }
         }
     "
@@ -831,12 +744,10 @@ fn runtime_function() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            apply {
-                if pow(x, 2) > 100 {
-                    accept
-                } else {
-                    reject
-                }
+            if pow(x, 2) > 100 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -846,15 +757,11 @@ fn runtime_function() {
     let s = src!(
         "
         filter-map main(x: u32) {
-            define {
-                pow = 3;
-            }
-            apply {
-                if pow(x, 2) > 100 {
-                    accept
-                } else {
-                    reject
-                }
+            let pow = 3;
+            if pow(x, 2) > 100 {
+                accept
+            } else {
+                reject
             }
         }
     "
@@ -867,12 +774,39 @@ fn issue_51() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                if true {
-                    foo;
-                }
-                accept
+            if true {
+                foo;
             }
+            accept
+        }
+    "
+    );
+
+    typecheck(s).unwrap_err();
+}
+
+#[test]
+fn self_referential_variable() {
+    let s = src!(
+        "
+        filter-map main() {
+            let a = a;
+            accept
+        }
+    "
+    );
+
+    typecheck(s).unwrap_err();
+}
+
+#[test]
+fn reference_variable_later_declared() {
+    let s = src!(
+        "
+        filter-map main() {
+            let a = b;
+            let b = 12;
+            accept
         }
     "
     );
@@ -885,9 +819,7 @@ fn use_globals() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                accept BLACKHOLE
-            }
+            accept BLACKHOLE
         }
         "
     );
@@ -909,9 +841,7 @@ fn use_context() {
     let s = src!(
         "
         filter-map main() {
-            apply {
-                accept foo;
-            }
+            accept foo;
         }
         "
     );


### PR DESCRIPTION
Previously:
```
filter-map foo() {
    define {
        a = 10;
    }
    apply {
        accept a
    }
}
```
Now:
```
filter-map foo() {
    let a = 10;
    accept a
}
```

This implementation matches all the rules laid out in https://github.com/NLnetLabs/roto/issues/86.

Type annotations are not in here yet.

Closes #86