### PR TITLE
Add some basic testing infrastructure for Roto scripts

### DIFF
--- a/examples/simple.roto
+++ b/examples/simple.roto
@@ -1,12 +1,25 @@
+function is_zero(x: IpAddr) -> bool {
+    x == 0.0.0.0
+}
+
 filter-map main(x: IpAddr) {
-    define {
-        y = 0.0.0.0;
+    if is_zero(x) {
+        accept
+    } else {
+        reject
     }
-    apply {
-        if x == y {
-            accept
-        } else {
-            reject
-        }
+}
+
+test is_zero_true {
+    if is_zero(1.1.1.1) {
+        reject
     }
+    accept
+}
+
+test is_zero_false {
+    if not is_zero(0.0.0.0) {
+        reject
+    }
+    accept
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -31,6 +31,13 @@ fn main() -> Result<(), roto::RotoReport> {
     let res = func.call(&mut (), "1.1.1.1".parse().unwrap());
     println!("main(1.1.1.1) = {res:?}");
 
+    let is_zero = compiled
+        .get_function::<(), (IpAddr,), bool>("is_zero")
+        .unwrap();
+
+    let res = is_zero.call(&mut (), "0.0.0.0".parse().unwrap());
+    println!("is_zero(0.0.0.0) = {res:?}");
+
     println!();
     let _ = compiled.run_tests(());
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -31,5 +31,8 @@ fn main() -> Result<(), roto::RotoReport> {
     let res = func.call(&mut (), "1.1.1.1".parse().unwrap());
     println!("main(1.1.1.1) = {res:?}");
 
+    println!();
+    let _ = compiled.run_tests(());
+
     Ok(())
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -23,6 +23,7 @@ pub enum Declaration {
     OutputStream(OutputStream),
     Record(RecordTypeDeclaration),
     Function(FunctionDeclaration),
+    Test(Test),
 }
 
 #[derive(Clone, Debug)]
@@ -55,6 +56,12 @@ pub struct FunctionDeclaration {
     pub ident: Meta<Identifier>,
     pub params: Meta<Params>,
     pub ret: Option<Meta<Identifier>>,
+    pub body: Meta<Block>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Test {
+    pub ident: Meta<Identifier>,
     pub body: Meta<Block>,
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -47,7 +47,7 @@ pub struct FilterMap {
     pub filter_type: FilterType,
     pub ident: Meta<Identifier>,
     pub params: Meta<Params>,
-    pub block: Meta<Block>,
+    pub body: Meta<Block>,
 }
 
 /// A function declaration, including the [`Block`] forming its definition

--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -158,18 +158,6 @@ fn check_roto_type(
     }
 }
 
-pub fn return_type_by_ref(registry: &TypeRegistry, rust_ty: TypeId) -> bool {
-    let Some(rust_ty) = registry.get(rust_ty) else {
-        return false;
-    };
-
-    #[allow(clippy::match_like_matches_macro)]
-    match rust_ty.description {
-        TypeDescription::Verdict(_, _) => true,
-        _ => todo!(),
-    }
-}
-
 /// Parameters of a Roto function
 ///
 /// This trait allows for checking the types against Roto types and converting

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -172,6 +172,7 @@ call_impl!(A, B, C, D, E, F, G);
 pub struct FunctionInfo {
     id: FuncId,
     signature: types::Signature,
+    return_by_ref: bool,
 }
 
 struct ModuleBuilder {
@@ -354,6 +355,7 @@ impl ModuleBuilder {
 
         let mut sig = self.inner.make_signature();
 
+        // This is the parameter for the context
         sig.params
             .push(AbiParam::new(self.cranelift_type(&IrType::Pointer)));
 
@@ -383,6 +385,7 @@ impl ModuleBuilder {
             name.to_string(),
             FunctionInfo {
                 id: func_id,
+                return_by_ref: ir_signature.return_ptr,
                 signature: signature.clone(),
             },
         );
@@ -1092,13 +1095,10 @@ impl Module {
             )
         })?;
 
-        let return_by_ref =
-            self.type_info.is_reference_type(&sig.return_type);
-
         let func_ptr = self.inner.0.get_finalized_function(id);
         Ok(TypedFunc {
             func: func_ptr,
-            return_by_ref,
+            return_by_ref: function_info.return_by_ref,
             _module: self.inner.clone(),
             _ty: PhantomData,
         })

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -16,17 +16,12 @@ use crate::{
         value::IrType,
         IrFunction,
     },
-    runtime::{
-        context::ContextDescription,
-        ty::{Reflect, GLOBAL_TYPE_REGISTRY},
-        RuntimeConstant,
-    },
+    runtime::{context::ContextDescription, ty::Reflect, RuntimeConstant},
     typechecker::{info::TypeInfo, scope::ScopeRef, types},
     IrValue, Verdict,
 };
 use check::{
-    check_roto_type_reflect, return_type_by_ref, FunctionRetrievalError,
-    RotoParams, TypeMismatch,
+    check_roto_type_reflect, FunctionRetrievalError, RotoParams, TypeMismatch,
 };
 use cranelift::{
     codegen::{
@@ -1054,9 +1049,9 @@ impl Module {
         );
 
         if failures == 0 {
-            Result::Err(())
-        } else {
             Result::Ok(())
+        } else {
+            Result::Err(())
         }
     }
 
@@ -1097,9 +1092,8 @@ impl Module {
             )
         })?;
 
-        let registry = GLOBAL_TYPE_REGISTRY.lock().unwrap();
         let return_by_ref =
-            return_type_by_ref(&registry, TypeId::of::<Return>());
+            self.type_info.is_reference_type(&sig.return_type);
 
         let func_ptr = self.inner.0.get_finalized_function(id);
         Ok(TypedFunc {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -53,7 +53,6 @@ fn accept() {
         .expect("No function found (or mismatched types)");
 
     let res = f.call(&mut ());
-    dbg!(std::mem::size_of::<Verdict<(), ()>>());
     assert_eq!(res, Verdict::Accept(()));
 }
 

--- a/src/lower/ir.rs
+++ b/src/lower/ir.rs
@@ -360,8 +360,8 @@ impl<'a> IrPrinter<'a> {
             } => format!(
                 "{}: {ty} = {}({}, {})",
                 self.var(to),
-                self.operand(ctx),
                 self.ident(func),
+                self.operand(ctx),
                 args.iter()
                     .map(|a| format!(
                         "{} = {}",

--- a/src/lower/match_expr.rs
+++ b/src/lower/match_expr.rs
@@ -213,12 +213,13 @@ impl Lowerer<'_> {
             let ty = self.type_info.type_of(&arm.body);
             let val = self.block(&arm.body);
             if let Some(val) = val {
-                let ty = self.lower_type(&ty);
-                self.add(Instruction::Assign {
-                    to: out.clone(),
-                    val,
-                    ty,
-                });
+                if let Some(ty) = self.lower_type(&ty) {
+                    self.add(Instruction::Assign {
+                        to: out.clone(),
+                        val,
+                        ty,
+                    });
+                }
                 any_assigned = true;
             }
             self.add(Instruction::Jump(continue_lbl));
@@ -267,15 +268,17 @@ impl Lowerer<'_> {
                     1 + self.type_info.padding_of(&ty, 1, self.runtime);
                 let val =
                     self.read_field(examinee.clone().into(), offset, &ty);
-                let ty = self.lower_type(&ty);
-                self.add(Instruction::Assign {
-                    to: Var {
-                        scope,
-                        kind: VarKind::Explicit(ident),
-                    },
-                    val,
-                    ty,
-                });
+                if let Some(val) = val {
+                    let ty = self.lower_type(&ty).unwrap();
+                    self.add(Instruction::Assign {
+                        to: Var {
+                            scope,
+                            kind: VarKind::Explicit(ident),
+                        },
+                        val,
+                        ty,
+                    });
+                }
             }
 
             let ident = Identifier::from(format!("guard_{}", i + 1));

--- a/src/parser/filter_map.rs
+++ b/src/parser/filter_map.rs
@@ -26,13 +26,13 @@ impl Parser<'_, '_> {
 
         let ident = self.identifier()?;
         let params = self.params()?;
-        let block = self.block()?;
+        let body = self.block()?;
 
         Ok(FilterMap {
             filter_type,
             ident,
             params,
-            block,
+            body,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,6 @@
-use crate::ast::{Declaration, FunctionDeclaration, Identifier, SyntaxTree};
+use crate::ast::{
+    Declaration, FunctionDeclaration, Identifier, SyntaxTree, Test,
+};
 use logos::{Lexer, SpannedIter};
 use std::{fmt::Display, iter::Peekable};
 use token::Token;
@@ -336,6 +338,7 @@ impl<'source, 'spans> Parser<'source, 'spans> {
                 Declaration::Record(self.record_type_assignment()?)
             }
             Token::Function => Declaration::Function(self.function()?),
+            Token::Test => Declaration::Test(self.test()?),
             _ => {
                 let (token, span) = self.next()?;
                 return Err(ParseError::expected(
@@ -371,6 +374,13 @@ impl<'source, 'spans> Parser<'source, 'spans> {
             body,
             ret,
         })
+    }
+
+    fn test(&mut self) -> ParseResult<Test> {
+        self.take(Token::Test)?;
+        let ident = self.identifier()?;
+        let body = self.block()?;
+        Ok(Test { ident, body })
     }
 }
 

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -115,6 +115,8 @@ pub enum Token<'s> {
     Some,
     #[token("table")]
     Table,
+    #[token("test")]
+    Test,
     #[token("through")]
     Through,
     #[token("type")]
@@ -211,6 +213,7 @@ impl Display for Token<'_> {
             Token::Rib => "rib",
             Token::Some => "some",
             Token::Table => "table",
+            Token::Test => "test",
             Token::Through => "through",
             Token::Type => "type",
             Token::UpTo => "up-to",

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -447,6 +447,10 @@ impl Lowered {
 }
 
 impl Compiled {
+    pub fn run_tests<Ctx: 'static>(&mut self, ctx: Ctx) -> Result<(), ()> {
+        self.module.run_tests(ctx)
+    }
+
     pub fn get_function<Ctx: 'static, Params: RotoParams, Return: Reflect>(
         &mut self,
         name: &str,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -447,6 +447,7 @@ impl Lowered {
 }
 
 impl Compiled {
+    #[allow(clippy::result_unit_err)]
     pub fn run_tests<Ctx: 'static>(&mut self, ctx: Ctx) -> Result<(), ()> {
         self.module.run_tests(ctx)
     }

--- a/src/typechecker/filter_map.rs
+++ b/src/typechecker/filter_map.rs
@@ -114,6 +114,31 @@ impl TypeChecker<'_> {
         Ok(())
     }
 
+    pub fn test(
+        &mut self,
+        scope: LocalScopeRef,
+        test: &ast::Test,
+    ) -> TypeResult<()> {
+        let ast::Test { ident, body } = test;
+
+        let scope = self
+            .scope_graph
+            .wrap(scope, ScopeType::Function(ident.node));
+
+        self.type_info
+            .function_scopes
+            .insert(ident.id, scope.into());
+
+        let unit = Box::new(Type::Primitive(Primitive::Unit));
+        let ret = Type::Verdict(unit.clone(), unit);
+        let ctx = Context {
+            expected_type: ret.clone(),
+            function_return_type: Some(ret),
+        };
+        self.block(scope, &ctx, body)?;
+        Ok(())
+    }
+
     pub fn function_type(
         &mut self,
         dec: &ast::FunctionDeclaration,

--- a/src/typechecker/filter_map.rs
+++ b/src/typechecker/filter_map.rs
@@ -20,7 +20,7 @@ impl TypeChecker<'_> {
             filter_type,
             ident,
             params,
-            block,
+            body,
         } = filter_map;
 
         let scope = self
@@ -44,7 +44,7 @@ impl TypeChecker<'_> {
             function_return_type: Some(ty.clone()),
         };
 
-        self.block(scope, &ctx, block)?;
+        self.block(scope, &ctx, body)?;
 
         if let Type::Var(x) = self.resolve_type(&a) {
             self.unify(

--- a/src/typechecker/info.rs
+++ b/src/typechecker/info.rs
@@ -96,8 +96,11 @@ impl TypeInfo {
         self.function_scopes[&x.into()]
     }
 
-    pub fn is_reference_type(&mut self, ty: &Type) -> bool {
+    pub fn is_reference_type(&mut self, ty: &Type, rt: &Runtime) -> bool {
         let ty = self.resolve(ty);
+        if self.size_of(&ty, rt) == 0 {
+            return false;
+        }
         matches!(
             ty,
             Type::Record(..)

--- a/src/typechecker/info.rs
+++ b/src/typechecker/info.rs
@@ -96,6 +96,20 @@ impl TypeInfo {
         self.function_scopes[&x.into()]
     }
 
+    pub fn is_reference_type(&mut self, ty: &Type) -> bool {
+        let ty = self.resolve(ty);
+        matches!(
+            ty,
+            Type::Record(..)
+                | Type::RecordVar(..)
+                | Type::NamedRecord(..)
+                | Type::Enum(..)
+                | Type::Verdict(..)
+                | Type::Primitive(Primitive::IpAddr | Primitive::Prefix)
+                | Type::BuiltIn(..)
+        )
+    }
+
     pub fn offset_of(
         &mut self,
         record: &Type,

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -304,6 +304,12 @@ impl TypeChecker<'_> {
             }
         }
 
+        for expr in &tree.declarations {
+            if let ast::Declaration::Test(t) = expr {
+                checker.test(module_scope, t)?
+            }
+        }
+
         Ok(checker.type_info)
     }
 

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -257,7 +257,7 @@ fn integer_inference() {
         "
         type Foo { x: u8 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let foo = Foo { x: 5 };
             accept
         }
@@ -270,7 +270,7 @@ fn integer_inference() {
         type Foo { x: u8 }
         type Bar { x: u8 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let a = 5;
             let foo = Foo { x: a };
             accept
@@ -284,7 +284,7 @@ fn integer_inference() {
         type Foo { x: u8 }
         type Bar { x: u8 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let a = 5;
             let foo = Foo { x: a };
             let bar = Bar { x: a };
@@ -299,7 +299,7 @@ fn integer_inference() {
         type Foo { x: u8 }
         type Bar { x: u32 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let a = 5;
             let foo = Foo { x: a };
             let bar = Bar { x: a };
@@ -314,7 +314,7 @@ fn integer_inference() {
         type Foo { x: u8 }
         type Bar { x: u32 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let foo = Foo { x: 5 };
             let bar = Bar { x: 5 };
             accept
@@ -331,7 +331,7 @@ fn assign_field_to_other_record() {
         type Foo { x: u8 }
         type Bar { x: u8 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let foo = Foo { x: 5 };
             let bar = Bar { x: foo.x };
             accept
@@ -345,7 +345,7 @@ fn assign_field_to_other_record() {
         type Foo { x: u8 }
         type Bar { x: u8 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let foo = Foo { x: 5 };
             let bar = Bar { x: foo.y };
             accept
@@ -359,7 +359,7 @@ fn assign_field_to_other_record() {
         type Foo { x: u8 }
         type Bar { x: u32 }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let foo = Foo { x: 5 };
             let bar = Bar { x: foo.x };
             accept
@@ -373,7 +373,7 @@ fn assign_field_to_other_record() {
 fn ip_addr_method() {
     let s = src!(
         "
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10;
             let is_four = 1 + p.is_ipv4();
             accept
@@ -384,7 +384,7 @@ fn ip_addr_method() {
 
     let s = src!(
         "
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10;
             let is_four = true && p.is_ipv4();
             accept
@@ -399,7 +399,7 @@ fn ip_addr_method() {
 fn ip_addr_method_of_method_return_type() {
     let s = src!(
         "
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10;
             let x = p.to_canonical().is_ipv4();
             accept
@@ -410,7 +410,7 @@ fn ip_addr_method_of_method_return_type() {
 
     let s = src!(
         "
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10;
             let x = p.is_ipv4().to_canonical();
             accept
@@ -425,7 +425,7 @@ fn ip_addr_method_of_method_return_type() {
 fn prefix_method() {
     let s = src!(
         "
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10/20;
             let add = p.address();
             accept
@@ -444,7 +444,7 @@ fn logical_expr() {
             (10 == 10) || (10 == 11)
         }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10/10;
             accept
         }
@@ -458,7 +458,7 @@ fn logical_expr() {
             (10 == 10) || ("hello" == 11)
         }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             let p = 10.10.10.10/10;
             accept
         }
@@ -482,7 +482,7 @@ fn send_output_stream() {
             });
         }
         
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             accept
         }
     "#
@@ -503,7 +503,7 @@ fn send_output_stream() {
             });
         }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             accept
         }
     "#
@@ -529,7 +529,7 @@ fn send_output_stream() {
             });
         }
 
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             accept
         }
     "#
@@ -555,7 +555,7 @@ fn send_output_stream() {
             });
         }
         
-        filter-map test(r: u32) {
+        filter-map my_map(r: u32) {
             accept
         }
     "#


### PR DESCRIPTION
A test is defined with
```
test name_of_the_test {
    ...
}
```
With a block that behaves like a `filter`, so if the test `accept`s then the test passes, but if it `reject`s it fails.

A test cannot be called by anything else and the name is allowed to collide with other things.