### PR TITLE
remove as _from Err type

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -92,7 +92,7 @@ impl std::fmt::Display for RotoReport {
 
         let mut file_cache = ariadne::FnCache::new(
             (move |id| {
-                Err(Box::new(format!("Failed to fetch source '{}'", id)) as _)
+                Err(Box::new(format!("Failed to fetch source '{}'", id)))
             }) as fn(&_) -> _,
         )
         .with_sources(sources);


### PR DESCRIPTION
Need this to get roto to not complain about type having to be annotated