### PR TITLE
Fixes for Rotonda

### DIFF
--- a/roto_examples/type_errors/accept_in_term.roto
+++ b/roto_examples/type_errors/accept_in_term.roto
@@ -2,10 +2,6 @@ function bar() -> bool {
     accept
 }
 
-filter foo() {
-    define {
-        rx msg: u32;
-    }
-
-    apply { accept }
+filter foo(msg: u32) {
+    accept
 }

--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -7,6 +7,7 @@ use crate::{
     typechecker::{
         info::TypeInfo,
         scope::{ResolvedName, ScopeRef},
+        scoped_display::ScopedDisplay,
         types::{Type, TypeDefinition},
     },
 };
@@ -96,13 +97,13 @@ fn check_roto_type(
     let Some(rust_ty) = registry.get(rust_ty) else {
         return Err(TypeMismatch {
             rust_ty: "unknown".into(),
-            roto_ty: roto_ty.to_string(),
+            roto_ty: roto_ty.display(&type_info.scope_graph).to_string(),
         });
     };
 
     let error_message = TypeMismatch {
         rust_ty: rust_ty.rust_name.to_string(),
-        roto_ty: roto_ty.to_string(),
+        roto_ty: roto_ty.display(&type_info.scope_graph).to_string(),
     };
 
     let mut roto_ty = type_info.resolve(roto_ty);

--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -308,6 +308,7 @@ macro_rules! params {
                 // fine.
                 #[allow(forgetting_copy_types)]
                 std::mem::forget(transformed);
+
                 if return_by_ref {
                     let func_ptr = unsafe {
                         std::mem::transmute::<*const u8, fn(*mut Return::Transformed, *mut Ctx, $($t::AsParam),*) -> ()>(func_ptr)

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -925,17 +925,18 @@ impl<'c> FuncGen<'c> {
                         clone,
                         &[src, dest],
                     );
+                } else {
+                    self.builder.emit_small_memory_copy(
+                        self.module.isa.frontend_config(),
+                        dest,
+                        src,
+                        *size as u64,
+                        0,
+                        0,
+                        true,
+                        MEMFLAGS,
+                    )
                 }
-                self.builder.emit_small_memory_copy(
-                    self.module.isa.frontend_config(),
-                    dest,
-                    src,
-                    *size as u64,
-                    0,
-                    0,
-                    true,
-                    MEMFLAGS,
-                )
             }
             ir::Instruction::Drop { var, drop } => {
                 if let Some(drop) = drop {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use inetnum::{addr::Prefix, asn::Asn};
-use roto_macros::{roto_function, roto_static_method};
+use roto_macros::{roto_function, roto_method, roto_static_method};
 
 use crate::{
     file_tree::FileSpec, pipeline::Compiled,
@@ -1931,4 +1931,52 @@ fn use_type_from_other_module_in_type() {
     let main = p.get_function::<(), (i32,), i32>("main").unwrap();
     let res = main.call(&mut (), 4);
     assert_eq!(res, 4);
+}
+
+#[test]
+fn mutate() {
+    let mut runtime = Runtime::new();
+
+    #[derive(Copy, Clone, Debug)]
+    struct MyType {
+        i: i16,
+    }
+
+    runtime
+        .register_copy_type::<*mut MyType>("my type")
+        .unwrap();
+
+    #[roto_method(runtime, *mut MyType)]
+    fn increase(t: &*mut MyType) {
+        eprintln!("increase, pre: {}", unsafe { (**t).i });
+        unsafe { (**t).i += 1 };
+        eprintln!("increase, post: {}", unsafe { (**t).i });
+    }
+
+    let s = src!(
+        "
+        filter main(t: MyType) {
+            t.increase();
+            accept t;
+        }
+    "
+    );
+
+    let mut p = compile_with_runtime(s, runtime);
+    let f = p
+        .get_function::<(), (roto::Val<*mut MyType>,) ,Verdict<roto::Val<*mut MyType>, ()>>("main")
+        .expect("No function found (or mismatched types)");
+
+    let mut t = MyType { i: 0 };
+    let res = f.call(&mut (), roto::Val(&mut t));
+
+    match res {
+        Verdict::Accept(val) => {
+            let val = unsafe { &*val.0 };
+            assert_eq!(val.i, 1, "returned value should be 1")
+        }
+        Verdict::Reject(_) => todo!(),
+    }
+
+    assert_eq!(t.i, 1, "mutated value should be 1");
 }

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1980,3 +1980,33 @@ fn mutate() {
 
     assert_eq!(t.i, 1, "mutated value should be 1");
 }
+
+#[test]
+fn return_vec() {
+    let mut runtime = Runtime::new();
+
+    #[derive(Clone, Debug, Default)]
+    #[allow(dead_code)]
+    struct MyType {
+        v: Vec<u8>,
+    }
+
+    runtime.register_clone_type::<MyType>("my type").unwrap();
+
+    let s = src!(
+        "
+        function main(t: MyType) -> MyType {
+            t
+        }
+    "
+    );
+
+    let mut p = compile_with_runtime(s, runtime);
+    let f = p
+        .get_function::<(), (roto::Val<MyType>,), roto::Val<MyType>>("main")
+        .expect("No function found (or mismatched types)");
+
+    let t = MyType { v: vec![0x01] };
+    let res = f.call(&mut (), roto::Val(t));
+    println!("Returned with {:?}", res.0.v.as_ptr());
+}

--- a/src/lower/ir.rs
+++ b/src/lower/ir.rs
@@ -369,7 +369,7 @@ impl<'a> IrPrinter<'a> {
     pub fn var(&self, var: &Var) -> String {
         let f = self.scope(var.scope);
         format!(
-            "{}::{}",
+            "{}.{}",
             f,
             match &var.kind {
                 VarKind::Explicit(name) => self.ident(name).to_string(),

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -290,8 +290,6 @@ impl<'r> Lowerer<'r> {
 
         let last = self.block(body);
 
-        self.drop_locals();
-
         self.return_expr(return_type, last);
 
         let name = self.type_info.resolved_name(ident);
@@ -359,7 +357,6 @@ impl<'r> Lowerer<'r> {
 
                 match kind {
                     ast::ReturnKind::Return => {
-                        self.drop_locals();
                         self.return_expr(&ty, op);
                     }
                     ast::ReturnKind::Accept => {
@@ -943,8 +940,10 @@ impl<'r> Lowerer<'r> {
                     ty,
                 );
             }
+            self.drop_locals();
             self.add(Instruction::Return(None));
         } else {
+            self.drop_locals();
             self.add(Instruction::Return(op));
         }
     }

--- a/src/parser/test_expressions.rs
+++ b/src/parser/test_expressions.rs
@@ -147,3 +147,9 @@ fn test_not_true_is_true() {
     let s = "not true == true";
     parse_expr(s).unwrap();
 }
+
+#[test]
+fn hex_number() {
+    let s = "0xffff029";
+    parse_expr(s).unwrap();
+}

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -282,7 +282,7 @@ impl<'s> Lexer<'s> {
         };
 
         let digit_idx = rest
-            .find(|c: char| !c.is_ascii_digit())
+            .find(|c: char| !c.is_ascii_hexdigit())
             .unwrap_or(rest.len());
 
         let (tok, span) = self.bump(2 + digit_idx);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -93,7 +93,8 @@ impl std::fmt::Display for RotoReport {
         let mut file_cache = ariadne::FnCache::new(
             (move |id| {
                 Err(Box::new(format!("Failed to fetch source '{}'", id)))
-            }) as fn(&_) -> _,
+            })
+                as fn(&_) -> Result<_, Box<dyn std::fmt::Debug + 'static>>,
         )
         .with_sources(sources);
 

--- a/src/typechecker/expr.rs
+++ b/src/typechecker/expr.rs
@@ -388,7 +388,7 @@ impl TypeChecker {
                     self.type_info.diverges.insert(id, diverges);
                     Ok(diverges)
                 } else {
-                    self.unify(&ctx.expected_type, &Type::bool(), id, None)?;
+                    self.unify(&ctx.expected_type, &Type::unit(), id, None)?;
 
                     // An if without else does not always diverge, because
                     // the condition could be false
@@ -398,7 +398,7 @@ impl TypeChecker {
                         .wrap(scope, ScopeType::Then(idx));
                     let _ = self.block(
                         then_scope,
-                        &ctx.with_type(Type::bool()),
+                        &ctx.with_type(Type::unit()),
                         t,
                     )?;
                     self.type_info.diverges.insert(id, false);

--- a/src/typechecker/info.rs
+++ b/src/typechecker/info.rs
@@ -6,6 +6,7 @@ use crate::{
     ast::Identifier,
     parser::meta::MetaId,
     runtime::layout::{Layout, LayoutBuilder},
+    typechecker::scoped_display::ScopedDisplay,
     Runtime,
 };
 
@@ -199,12 +200,15 @@ impl TypeInfo {
             Type::Name(type_name) => {
                 type_def = self.resolve_type_name(type_name);
                 let TypeDefinition::Record(_, fields) = &type_def else {
-                    panic!("Can't get offsets in a type that's not a record, but {record}")
+                    panic!("Can't get offsets in a type that's not a record, but {}", record.display(&self.scope_graph))
                 };
                 fields
             }
             _ => {
-                panic!("Can't get offsets in a type that's not a record, but {record}")
+                panic!(
+                    "Can't get offsets in a type that's not a record, but {}",
+                    record.display(&self.scope_graph)
+                )
             }
         };
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -100,6 +100,7 @@ use cycle::detect_type_cycles;
 use scope::{
     ModuleScope, ResolvedName, ScopeRef, ScopeType, StubDeclarationKind,
 };
+use scoped_display::ScopedDisplay;
 use std::{borrow::Borrow, collections::HashMap};
 use types::{FunctionDefinition, Type, TypeDefinition, TypeName};
 
@@ -114,6 +115,7 @@ mod expr;
 mod function;
 pub mod info;
 pub mod scope;
+pub mod scoped_display;
 #[cfg(test)]
 mod tests;
 pub mod types;
@@ -840,10 +842,18 @@ impl TypeChecker {
             // Explitcit type variables need to be replaced with fresh type
             // variable. If they appear here, something has gone wrong.
             (a @ ExplicitVar(_), b) => {
-                ice!("Cannot unify explicit var: {a}, {b}")
+                ice!(
+                    "Cannot unify explicit var: {}, {}",
+                    a.display(&self.type_info.scope_graph),
+                    b.display(&self.type_info.scope_graph),
+                )
             }
             (a, b @ ExplicitVar(_)) => {
-                ice!("Cannot unify explicit var: {a}, {b}")
+                ice!(
+                    "Cannot unify explicit var: {}, {}",
+                    a.display(&self.type_info.scope_graph),
+                    b.display(&self.type_info.scope_graph),
+                )
             }
             // The never type is special and unifies with anything
             (Never, x) | (x, Never) => x,

--- a/src/typechecker/scope.rs
+++ b/src/typechecker/scope.rs
@@ -1,6 +1,7 @@
 //! Type checking scopes
 
-use std::collections::{btree_map::Entry, BTreeMap};
+use core::fmt;
+use std::collections::btree_map::{BTreeMap, Entry};
 
 use crate::{
     ast::Identifier,
@@ -8,6 +9,7 @@ use crate::{
 };
 
 use super::{
+    scoped_display::ScopedDisplay,
     types::{FunctionDefinition, TypeDefinition},
     Type,
 };
@@ -28,6 +30,21 @@ impl ScopeRef {
 pub struct ResolvedName {
     pub scope: ScopeRef,
     pub ident: Identifier,
+}
+
+impl ScopedDisplay for ResolvedName {
+    fn fmt(
+        &self,
+        graph: &ScopeGraph,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        let scope = graph.print_scope(self.scope);
+        if scope.is_empty() {
+            write!(f, "{}", self.ident)
+        } else {
+            write!(f, "{scope}.{}", self.ident)
+        }
+    }
 }
 
 /// A declaration in a [`ScopeGraph`]

--- a/src/typechecker/scoped_display.rs
+++ b/src/typechecker/scoped_display.rs
@@ -1,0 +1,39 @@
+use core::fmt;
+
+use super::scope::ScopeGraph;
+
+pub trait ScopedDisplay: Sized {
+    fn fmt(
+        &self,
+        graph: &ScopeGraph,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result;
+
+    fn display<'a>(
+        &'a self,
+        graph: &'a ScopeGraph,
+    ) -> impl fmt::Display + 'a {
+        ScopedPrinter { graph, inner: self }
+    }
+}
+
+impl<T: fmt::Display> ScopedDisplay for T {
+    fn fmt(
+        &self,
+        _graph: &ScopeGraph,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+struct ScopedPrinter<'a, T: ScopedDisplay> {
+    graph: &'a ScopeGraph,
+    inner: &'a T,
+}
+
+impl<T: ScopedDisplay> fmt::Display for ScopedPrinter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(self.graph, f)
+    }
+}

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -34,6 +34,12 @@ fn typecheck_with_runtime(
 }
 
 #[test]
+fn empty() {
+    let s = src!("");
+    assert!(typecheck(s).is_ok());
+}
+
+#[test]
 fn one_record() {
     let s = src!("type Foo { a: u32 }");
     assert!(typecheck(s).is_ok());

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -342,6 +342,19 @@ fn assign_field_to_other_record() {
 }
 
 #[test]
+fn if_without_body() {
+    let s = src!(
+        "
+           function foo() {
+               if true {}
+           }
+        "
+    );
+
+    assert!(typecheck(s).is_ok());
+}
+
+#[test]
 fn ip_addr_method() {
     let s = src!(
         "


### PR DESCRIPTION
Collection of fixes for Rotonda.

- Allow hex numbers to actually contain hex digits. The lexer only lexed decimal digits, whoops.
- Make sure if without else unifies with unit instead of bool, which I guess was a mistake introduced while refactoring, because this never should have been the case.
- Making the printing of types much better with `ScopedDisplay`.