### PR TITLE
Several fixes to cloning and dropping

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -940,7 +940,7 @@ impl<'c> FuncGen<'c> {
             }
             ir::Instruction::Drop { var, drop } => {
                 if let Some(drop) = drop {
-                    let (var, _) = self.operand(&Operand::Place(var.clone()));
+                    let (var, _) = self.operand(&var);
                     let pointer_ty = self.module.isa.pointer_type();
                     let drop = self
                         .ins()

--- a/src/lower/eval.rs
+++ b/src/lower/eval.rs
@@ -637,7 +637,8 @@ pub fn eval(
             }
             Instruction::Drop { var, drop } => {
                 if let Some(drop) = drop {
-                    let Some(&IrValue::Pointer(val)) = vars.get(var) else {
+                    let &IrValue::Pointer(val) = eval_operand(&vars, var)
+                    else {
                         panic!()
                     };
 

--- a/src/lower/ir.rs
+++ b/src/lower/ir.rs
@@ -37,13 +37,13 @@ use super::{
 };
 
 /// Human-readable place
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Var {
     pub scope: ScopeRef,
     pub kind: VarKind,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum VarKind {
     Explicit(Identifier),
     Tmp(usize),
@@ -242,7 +242,7 @@ pub enum Instruction {
     /// For primitives and copy types, this is a noop. For more complex types
     /// it matches Rust's Drop.
     Drop {
-        var: Var,
+        var: Operand,
         /// Pointer to the drop implementation of the type
         drop: Option<unsafe extern "C" fn(*mut ())>,
     },
@@ -690,10 +690,10 @@ impl<'a> IrPrinter<'a> {
                 var,
                 drop: Some(drop),
             } => {
-                format!("mem::drop({}, with={drop:?})", self.var(var),)
+                format!("mem::drop({}, with={drop:?})", self.operand(var),)
             }
             Drop { var, drop: None } => {
-                format!("mem::drop({})", self.var(var),)
+                format!("mem::drop({}, noop)", self.operand(var),)
             }
         }
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -78,10 +78,13 @@ pub enum Movability {
     Copy,
 
     // This type needs a clone and drop function.
-    CloneDrop {
-        clone: unsafe extern "C" fn(*const (), *mut ()),
-        drop: unsafe extern "C" fn(*mut ()),
-    },
+    CloneDrop(CloneDrop),
+}
+
+#[derive(Debug)]
+pub struct CloneDrop {
+    pub clone: unsafe extern "C" fn(*const (), *mut ()),
+    pub drop: unsafe extern "C" fn(*mut ()),
 }
 
 unsafe extern "C" fn extern_clone<T: Clone>(from: *const (), to: *mut ()) {
@@ -281,10 +284,10 @@ impl Runtime {
         name: &str,
         docstring: &str,
     ) -> Result<(), String> {
-        let movability = Movability::CloneDrop {
+        let movability = Movability::CloneDrop(CloneDrop {
             clone: extern_clone::<T> as _,
             drop: extern_drop::<T> as _,
-        };
+        });
         self.register_type_with_name_internal::<T>(
             name, movability, docstring,
         )

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -191,7 +191,7 @@ impl TypeDefinition {
         }
     }
 
-    /// Instatiate the type definition with fresh type variables
+    /// Instantiate the type definition with fresh type variables
     pub fn instantiate(&self, fresh_var: impl FnMut() -> Type) -> Type {
         self.type_name().instantiate(fresh_var)
     }


### PR DESCRIPTION
- Ensure that variables are dropped at the end of their scope.
- Ensure that a return drops everything
- Drop and clone registered types within records and enums. A limitation here currently is that we always branch on the enum variant, even if the types in that variant do not require `drop`. I would hope that cranelift would optimize this, but maybe we have to fix that. Another probably even more serious limitation is that we now clone each individual field in a record/enum instead of just memcpying the entire record. Cranelift does not have enough information about that to optimize it.
- Optimize pointer offsets, so that `0` offset doesn't result in an additional instruction