### PR TITLE
Make registered functions take `Val<T>` instead of `&T`

### DIFF
--- a/examples/addr_range.rs
+++ b/examples/addr_range.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // Register the contains method with a docstring
     #[roto_method(runtime, AddrRange)]
-    fn contains(range: &AddrRange, addr: &IpAddr) -> bool {
+    fn contains(range: Val<AddrRange>, addr: Val<IpAddr>) -> bool {
         range.min <= *addr && *addr <= range.max
     }
 

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1947,7 +1947,7 @@ fn mutate() {
         .unwrap();
 
     #[roto_method(runtime, *mut MyType)]
-    fn increase(t: &*mut MyType) {
+    fn increase(mut t: Val<*mut MyType>) {
         eprintln!("increase, pre: {}", unsafe { (**t).i });
         unsafe { (**t).i += 1 };
         eprintln!("increase, post: {}", unsafe { (**t).i });
@@ -1964,11 +1964,11 @@ fn mutate() {
 
     let mut p = compile_with_runtime(s, runtime);
     let f = p
-        .get_function::<(), (roto::Val<*mut MyType>,) ,Verdict<roto::Val<*mut MyType>, ()>>("main")
+        .get_function::<(), (Val<*mut MyType>,) ,Verdict<Val<*mut MyType>, ()>>("main")
         .expect("No function found (or mismatched types)");
 
     let mut t = MyType { i: 0 };
-    let res = f.call(&mut (), roto::Val(&mut t));
+    let res = f.call(&mut (), Val(&mut t));
 
     match res {
         Verdict::Accept(val) => {
@@ -2056,15 +2056,13 @@ fn name_collision() {
         runtime.register_clone_type::<B>("").unwrap();
 
         #[roto_method(runtime, A, foo)]
-        fn foo_a(_t: &A) -> bool {
+        fn foo_a(_: Val<A>) -> bool {
             true
         }
 
         #[roto_method(runtime, B, foo)]
-        #[allow(unreachable_code)]
-        fn foo_b(_t: &B) -> bool {
-            unreachable!();
-            false
+        fn foo_b(_: Val<B>) -> bool {
+            unreachable!()
         }
 
         let s = src!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use roto_macros::{
 pub use runtime::{
     context::{Context, ContextField},
     optional::Optional,
+    ty::Reflect,
     val::Val,
     verdict::Verdict,
     DocumentedFunc, Runtime, RuntimeType,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -569,17 +569,17 @@ impl Runtime {
                 }
             } else {
                 match ty.description {
-                    TypeDescription::ConstPtr(_) => {} // correct!
+                    TypeDescription::MutPtr(_) => {} // correct!
                     TypeDescription::Leaf => {
                         let ty = self.type_registry.get(ty.type_id).unwrap();
                         return Err(format!(
-                            "Type `{}` should be passed by pointer. Try adding `*const` or `&`",
+                            "Type `{}` should be passed by pointer. Try adding `*mut`",
                             ty.rust_name,
                         ));
                     }
-                    TypeDescription::MutPtr(_) => {
+                    TypeDescription::ConstPtr(_) => {
                         return Err(
-                            "Parameters cannot be mutable pointers. Try removing `&mut` or `*mut`".to_string()
+                            "Parameters cannot be mutable pointers. Try removing `&` or `*const`".to_string()
                         );
                     }
                     _ => unreachable!("check_type should fail before this"),
@@ -923,8 +923,8 @@ impl Runtime {
         /// 192.169.0.0 / 16
         /// ```
         #[roto_static_method(rt, Prefix, new)]
-        fn prefix_new(ip: &IpAddr, len: u8) -> Prefix {
-            Prefix::new(*ip, len).unwrap()
+        fn prefix_new(ip: IpAddr, len: u8) -> Prefix {
+            Prefix::new(ip, len).unwrap()
         }
 
         /// Check whether two IP addresses are equal
@@ -944,7 +944,7 @@ impl Runtime {
         /// 192.0.0.0.eq(192.0.0.0)  # -> true
         /// ```
         #[roto_method(rt, IpAddr, eq)]
-        fn ipaddr_eq(a: &IpAddr, b: &IpAddr) -> bool {
+        fn ipaddr_eq(a: IpAddr, b: IpAddr) -> bool {
             a == b
         }
 
@@ -955,7 +955,7 @@ impl Runtime {
         /// ::.is_ipv4()      # -> false
         /// ```
         #[roto_method(rt, IpAddr)]
-        fn is_ipv4(ip: &IpAddr) -> bool {
+        fn is_ipv4(ip: IpAddr) -> bool {
             ip.is_ipv4()
         }
 
@@ -966,13 +966,13 @@ impl Runtime {
         /// ::.is_ipv6()      # -> true
         /// ```
         #[roto_method(rt, IpAddr)]
-        fn is_ipv6(ip: &IpAddr) -> bool {
+        fn is_ipv6(ip: IpAddr) -> bool {
             ip.is_ipv6()
         }
 
         /// Converts this address to an IPv4 if it is an IPv4-mapped IPv6 address, otherwise it returns self as-is.
         #[roto_method(rt, IpAddr)]
-        fn to_canonical(ip: &IpAddr) -> IpAddr {
+        fn to_canonical(ip: IpAddr) -> IpAddr {
             ip.to_canonical()
         }
 
@@ -1002,7 +1002,7 @@ impl Runtime {
         /// "hello".append(" ").append("world") # -> "hello world"
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn append(a: &Arc<str>, b: &Arc<str>) -> Arc<str> {
+        fn append(a: Arc<str>, b: Arc<str>) -> Arc<str> {
             format!("{a}{b}").into()
         }
 
@@ -1013,7 +1013,7 @@ impl Runtime {
         /// "haystack".contains("corn") # -> false
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn contains(haystack: &Arc<str>, needle: &Arc<str>) -> bool {
+        fn contains(haystack: Arc<str>, needle: Arc<str>) -> bool {
             haystack.contains(needle.as_ref())
         }
 
@@ -1024,7 +1024,7 @@ impl Runtime {
         /// "haystack".contains("trees") # -> false
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn starts_with(s: &Arc<str>, prefix: &Arc<str>) -> bool {
+        fn starts_with(s: Arc<str>, prefix: Arc<str>) -> bool {
             s.starts_with(prefix.as_ref())
         }
 
@@ -1035,7 +1035,7 @@ impl Runtime {
         /// "haystack".contains("black") # -> false
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn ends_with(s: &Arc<str>, suffix: &Arc<str>) -> bool {
+        fn ends_with(s: Arc<str>, suffix: Arc<str>) -> bool {
             s.ends_with(suffix.as_ref())
         }
 
@@ -1045,7 +1045,7 @@ impl Runtime {
         /// "LOUD".to_lowercase() # -> "loud"
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn to_lowercase(s: &Arc<str>) -> Arc<str> {
+        fn to_lowercase(s: Arc<str>) -> Arc<str> {
             s.to_lowercase().into()
         }
 
@@ -1055,7 +1055,7 @@ impl Runtime {
         /// "quiet".to_uppercase() # -> "QUIET"
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn to_uppercase(s: &Arc<str>) -> Arc<str> {
+        fn to_uppercase(s: Arc<str>) -> Arc<str> {
             s.to_uppercase().into()
         }
 
@@ -1065,7 +1065,7 @@ impl Runtime {
         /// "ha".repeat(6) # -> "hahahahahaha"
         /// ```
         #[roto_method(rt, Arc<str>)]
-        fn repeat(s: &Arc<str>, n: u32) -> Arc<str> {
+        fn repeat(s: Arc<str>, n: u32) -> Arc<str> {
             s.repeat(n as usize).into()
         }
 

--- a/src/runtime/val.rs
+++ b/src/runtime/val.rs
@@ -1,3 +1,5 @@
+use std::ops::{Deref, DerefMut};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Val<T>(pub T);
@@ -5,5 +7,19 @@ pub struct Val<T>(pub T);
 impl<T> From<T> for Val<T> {
     fn from(value: T) -> Self {
         Self(value)
+    }
+}
+
+impl<T> Deref for Val<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Val<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }


### PR DESCRIPTION
This makes the semantics clearer, because Roto values are always passed by value and not by reference.

Additionally, this makes the use of runtime-registered types more symmetric, because the other Roto-Rust boundary already uses `Val<T>`.

A "side-effect" of this PR is that irrefutable patterns can now be used as parameters. That was a needless restriction.