### PR TITLE
Delay forcing filtermap types to unit

### DIFF
--- a/src/typechecker/function.rs
+++ b/src/typechecker/function.rs
@@ -9,7 +9,7 @@ use crate::{
 use super::{
     expr::Context,
     scope::{ScopeRef, ScopeType},
-    types::{Type, TypeName},
+    types::Type,
     TypeChecker, TypeResult,
 };
 
@@ -29,7 +29,7 @@ impl TypeChecker {
 
         let ty = self.type_info.type_of(ident);
         let Type::Function(_, return_type) = &ty else {
-            panic!()
+            ice!()
         };
 
         let scope = self
@@ -49,33 +49,6 @@ impl TypeChecker {
         };
 
         self.block(scope, &ctx, body)?;
-
-        let Type::Name(TypeName { name: _, arguments }) = &**return_type
-        else {
-            ice!("return type of a filter-map should always be a verdict")
-        };
-        let [a, r] = &arguments[..] else {
-            ice!("return type of a filter-map should always be a verdict")
-        };
-
-        if let Type::Var(x) = self.resolve_type(a) {
-            self.unify(
-                &Type::Var(x),
-                &Type::unit(),
-                filter_map.ident.id,
-                None,
-            )
-            .unwrap();
-        }
-        if let Type::Var(x) = self.resolve_type(r) {
-            self.unify(
-                &Type::Var(x),
-                &Type::unit(),
-                filter_map.ident.id,
-                None,
-            )
-            .unwrap();
-        }
 
         let param_types = params.into_iter().map(|(_, t)| t).collect();
 

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -944,3 +944,34 @@ fn silly_import_loop() {
     ));
     typecheck(tree).unwrap_err();
 }
+
+#[test]
+fn filtermap_calling_filtermap() {
+    let s = src!(
+        "
+            filtermap foo() {
+                accept 5
+            }
+
+            filtermap bar() {
+                foo()
+            }
+        "
+    );
+
+    typecheck(s).unwrap();
+
+    let s = src!(
+        "
+            filtermap bar() {
+                foo()
+            }
+
+            filtermap foo() {
+                accept 5
+            }
+        "
+    );
+
+    typecheck(s).unwrap();
+}


### PR DESCRIPTION
This fixes inference issues around filtermaps calling each other.

Closes https://github.com/NLnetLabs/roto/issues/145