### PR TITLE
Implement first version of the assignment operator

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -133,6 +133,12 @@ pub enum Expr {
     /// A unary not expression
     Not(Box<Meta<Expr>>),
 
+    /// An assignment expression
+    ///
+    /// Arbitrary place expressions should be allowed at some point, but for
+    /// now that's not supported.
+    Assign(Meta<Path>, Box<Meta<Expr>>),
+
     /// A binary operator expression
     ///
     /// Takes a left operand, the operator and the right operand

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -2165,3 +2165,22 @@ fn str_not_equals() {
     assert!(func.call(&mut (), "foo".into()));
     assert!(!func.call(&mut (), "/".into()));
 }
+
+#[test]
+fn assignment() {
+    let s = src!(
+        "
+            function foo() -> i32 {
+                let x = 4;
+                x = x + 3;
+                x
+            }
+        "
+    );
+    let runtime = Runtime::new();
+
+    let mut compiled = s.compile(runtime).unwrap();
+    let func = compiled.get_function::<(), (), i32>("foo").unwrap();
+
+    assert_eq!(func.call(&mut ()), 7);
+}

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -528,6 +528,35 @@ impl<'r> Lowerer<'r> {
                 );
                 self.read_field(op, offset, &ty)
             }
+            ast::Expr::Assign(p, e) => {
+                let op = self.expr(e)?;
+
+                let path_kind = self.type_info.path_kind(p).clone();
+                let ResolvedPath::Value(PathValue {
+                    name,
+                    kind: _,
+                    ty,
+                    fields: _,
+                }) = path_kind
+                else {
+                    ice!("should be rejected by type checker");
+                };
+
+                let Some(ty) = self.lower_type(&ty) else {
+                    return None;
+                };
+
+                self.add(Instruction::Assign {
+                    to: Var {
+                        scope: name.scope,
+                        kind: VarKind::Explicit(name.ident),
+                    },
+                    val: op,
+                    ty,
+                });
+
+                None
+            }
             ast::Expr::Path(p) => {
                 let path_kind = self.type_info.path_kind(p).clone();
 

--- a/src/parser/test_expressions.rs
+++ b/src/parser/test_expressions.rs
@@ -11,6 +11,24 @@ fn parse_expr(s: &str) -> ParseResult<Meta<Expr>> {
 }
 
 #[test]
+fn assign_expr_1() {
+    let s = "a = 4";
+    parse_expr(s).unwrap();
+}
+
+#[test]
+fn assign_expr_2() {
+    let s = "a + 3 = 4";
+    parse_expr(s).unwrap_err();
+}
+
+#[test]
+fn assign_expr_3() {
+    let s = "a = 4 + 3";
+    parse_expr(s).unwrap();
+}
+
+#[test]
 fn test_logical_expr_1() {
     let s =
         "( blaffer.waf().contains(my_set) ) || ( blaffer.blaf() < bop() )";

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -975,3 +975,30 @@ fn filtermap_calling_filtermap() {
 
     typecheck(s).unwrap();
 }
+
+#[test]
+fn assignment() {
+    let s = src!(
+        "
+            function foo() -> i32 {
+                let x = 4;
+                x = x + 3;
+                x
+            }
+        "
+    );
+
+    typecheck(s).unwrap();
+
+    let s = src!(
+        "
+            function foo() -> i32 {
+                let x = false;
+                x = x + 3;
+                x
+            }
+        "
+    );
+
+    typecheck(s).unwrap_err();
+}


### PR DESCRIPTION
For now, this can only assign to local variables and not to full paths, which is what I ultimately want to achieve as a (partial) solution to https://github.com/NLnetLabs/roto/issues/156 and other issues.

Having an assignment operator is also useful for things like setting values based on `if-else`:
```
let x = 0;
if something {
    x = 3;
} else {
    x = 5;
}
```
You can write this as:
```
let x = if something { 3 } else { 5 };
```
But that gets annoying with multiple variables or when the branches call other functions.