### PR TITLE
Exclude some things from `cargo publish`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
+exclude = [
+  "/.github",
+  "/tests",
+  "/vscode-extension",
+]
 
 [dependencies]
 ariadne = "0.5.1"


### PR DESCRIPTION
In preparation of https://github.com/NLnetLabs/roto/pull/150 too because that adds a lot of files.