### PR TITLE
Multi imports

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -21,7 +21,7 @@ pub enum Declaration {
     Record(RecordTypeDeclaration),
     Function(FunctionDeclaration),
     Test(Test),
-    Import(Meta<Path>),
+    Import(Vec<Meta<Path>>),
 }
 
 #[derive(Clone, Debug)]

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1880,6 +1880,40 @@ fn use_type_in_function_argument() {
 }
 
 #[test]
+fn import_list() {
+    let pkg = source_file!(
+        "pkg",
+        "
+            import foo.{double, triple};
+            function main(x: i32) -> i32 {
+                triple(double(x))
+            }
+        "
+    );
+    let foo = source_file!(
+        "foo",
+        "
+            function double(x: i32) -> i32 {
+                2 * x
+            }
+
+            function triple(x: i32) -> i32 {
+                3 * x
+            }
+        "
+    );
+
+    let tree = FileTree::file_spec(FileSpec::Directory(
+        pkg,
+        vec![FileSpec::File(foo)],
+    ));
+    let mut p = compile(tree);
+    let main = p.get_function::<(), fn(i32) -> i32>("main").unwrap();
+    let res = main.call(&mut (), 1);
+    assert_eq!(res, 6);
+}
+
+#[test]
 fn use_type_in_function_return_type() {
     let pkg = source_file!(
         "pkg",

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -56,10 +56,8 @@ impl Parser<'_, '_> {
             }
 
             if self.peek_is(Token::Keyword(Keyword::Import)) {
-                self.take(Token::Keyword(Keyword::Import))?;
-                let path = self.path()?;
-                self.take(Token::SemiColon)?;
-                imports.push(path);
+                let mut paths = self.import()?;
+                imports.append(&mut paths);
             } else if self.peek_is(Token::Keyword(Keyword::Let)) {
                 let start = self.take(Token::Keyword(Keyword::Let))?;
                 let identifier = self.identifier()?;
@@ -846,6 +844,51 @@ impl Parser<'_, '_> {
         let span =
             self.merge_spans(idents.first().unwrap(), idents.last().unwrap());
         Ok(self.add_span(span, Path { idents }))
+    }
+
+    pub(super) fn path_expr(&mut self) -> ParseResult<Vec<Meta<Path>>> {
+        let mut paths: Vec<Meta<Path>> = Vec::new();
+        let mut root: Path = Path { idents: Vec::new() };
+        loop {
+            if self.peek_is(Token::CurlyLeft) {
+                let sub_paths = self.path_list()?;
+
+                for mut sp in sub_paths {
+                    let mut new_idents = root.idents.clone();
+                    new_idents.append(&mut sp.idents);
+                    paths.push(sp);
+                }
+                break;
+            }
+
+            let ident: Meta<Identifier> = self.path_item()?;
+            root.idents.push(ident);
+
+            if !self.next_is(Token::Period) {
+                let span = self.merge_spans(
+                    root.idents.first().unwrap(),
+                    root.idents.last().unwrap(),
+                );
+                paths.push(self.add_span(span, root));
+                break;
+            }
+        }
+
+        Ok(paths)
+    }
+
+    fn path_list(&mut self) -> ParseResult<Vec<Meta<Path>>> {
+        let mut paths: Vec<Meta<Path>> = Vec::new();
+        self.take(Token::CurlyLeft)?;
+        loop {
+            let mut path = self.path_expr()?;
+            paths.append(&mut path);
+            if !self.next_is(Token::Comma) {
+                break;
+            }
+        }
+        self.take(Token::CurlyRight)?;
+        Ok(paths)
     }
 
     fn path_item(&mut self) -> ParseResult<Meta<Identifier>> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -394,9 +394,9 @@ impl<'source, 'spans> Parser<'source, 'spans> {
         Ok(Test { ident, body })
     }
 
-    fn import(&mut self) -> ParseResult<Meta<Path>> {
+    fn import(&mut self) -> ParseResult<Vec<Meta<Path>>> {
         self.take(Token::Keyword(Keyword::Import))?;
-        let path = self.path()?;
+        let path = self.path_expr()?;
         self.take(Token::SemiColon)?;
         Ok(path)
     }

--- a/src/parser/test_sections.rs
+++ b/src/parser/test_sections.rs
@@ -91,3 +91,51 @@ fn block_import_2() {
     ";
     parse(s).unwrap();
 }
+
+#[test]
+fn list_import() {
+    let s = "
+        function myfunction() {
+            import foo.{bar1, bar2};
+            1 + 1;
+        }
+    ";
+
+    parse(s).unwrap();
+}
+
+#[test]
+fn nested_list_import() {
+    let s = "
+        function myfunction() {
+            import foo.{baz.{fn1, fn2, fn3}, baz.{bar1, bar2}};
+            1 + 1;
+        }
+    ";
+
+    parse(s).unwrap();
+}
+
+#[test]
+fn sublists_only_import() {
+    let s = "
+        function myfunction() {
+            import foo.{{fn1, fn2, fn3}, {bar1, bar2}};
+            1 + 1;
+        }
+    ";
+
+    parse(s).unwrap();
+}
+
+#[test]
+fn sublist_sublist_import() {
+    let s = "
+        function myfunction() {
+            import foo.{item1.{fn1, fn2}, item2.{item3.fn3, item4.{fn5, fn6}}};
+            1 + 1;
+        }
+    ";
+
+    parse(s).unwrap();
+}

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -496,10 +496,12 @@ impl TypeChecker {
         for &(scope, module) in modules {
             let mut paths = Vec::new();
             for expr in &module.ast.declarations {
-                let ast::Declaration::Import(path) = expr else {
+                let ast::Declaration::Import(new_paths) = expr else {
                     continue;
                 };
-                paths.push(path);
+                for path in new_paths {
+                    paths.push(path);
+                }
             }
             self.imports(scope, &paths)?;
         }


### PR DESCRIPTION
#125 

Last node in an import path can be a list of items to import. Each item in the list can be a full path.

```
import foo.{bar1, bar2};
import foo.{bar.fn1, bar2.{fn2, fn3}};
```

Notes:
- I changed `block()` to use `import()` instead of parsing the statement itself. Any reason this should be separate?
- I've left `path()` as is since it's been using a few places unrelated to importing

Thanks to algeron for the detailed comment on the issue, it was super helpful for getting started.