### PR TITLE
Refine public API

### DIFF
--- a/examples/addr_range.rs
+++ b/examples/addr_range.rs
@@ -1,6 +1,6 @@
-use std::{net::IpAddr, path::Path};
+use std::net::IpAddr;
 
-use roto::{roto_method, FileTree, Runtime, Val, Verdict};
+use roto::{roto_method, Runtime, Val, Verdict};
 
 #[derive(Clone)]
 struct AddrRange {
@@ -9,8 +9,6 @@ struct AddrRange {
 }
 
 fn main() {
-    let path = Path::new("./examples/addr_range.roto");
-
     // Create a runtime
     let mut runtime = Runtime::new();
 
@@ -26,7 +24,7 @@ fn main() {
     }
 
     // Compile the program with our runtime
-    let mut program = FileTree::read(path).compile(runtime).unwrap();
+    let mut program = runtime.compile("examples/addr_range.roto").unwrap();
 
     // Extract the function
     let function = program

--- a/examples/hello_world.roto
+++ b/examples/hello_world.roto
@@ -1,0 +1,3 @@
+function main() {
+    print(5);
+}

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,0 +1,19 @@
+use roto::Runtime;
+
+fn main() -> Result<(), roto::RotoReport> {
+    let mut runtime = Runtime::new();
+    runtime.add_io_functions();
+
+    let mut compiled = runtime
+        .compile("examples/hello_world.roto")
+        .inspect_err(|e| eprintln!("{e}"))?;
+
+    let func = compiled
+        .get_function::<(), fn() -> ()>("main")
+        .inspect_err(|e| eprintln!("{e}"))
+        .unwrap();
+
+    func.call(&mut ());
+
+    Ok(())
+}

--- a/examples/modules.rs
+++ b/examples/modules.rs
@@ -1,14 +1,12 @@
-use std::path::Path;
-
-use roto::{FileTree, Runtime};
+use roto::Runtime;
 
 fn main() -> Result<(), roto::RotoReport> {
     #[cfg(feature = "logger")]
     env_logger::init();
 
     let runtime = Runtime::new();
-    let mut compiled = FileTree::directory(Path::new("examples/modules"))
-        .compile(runtime)
+    let mut compiled = runtime
+        .compile("examples/modules")
         .inspect_err(|e| eprintln!("{e}"))?;
 
     let f = compiled.get_function::<(), fn(i32) -> i32>("main").unwrap();

--- a/examples/optional.rs
+++ b/examples/optional.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use roto::{roto_static_method, FileTree, Runtime, Val};
+use roto::{roto_static_method, Runtime, Val};
 
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
@@ -29,8 +29,8 @@ fn main() -> Result<(), roto::RotoReport> {
         Some(Val(NonEmptyString { s }))
     }
 
-    let mut compiled = FileTree::single_file("examples/optional.roto")
-        .compile(runtime)
+    let mut compiled = runtime
+        .compile("examples/optional.roto")
         .inspect_err(|e| eprintln!("{e}"))?;
 
     let func = compiled

--- a/examples/presentation.rs
+++ b/examples/presentation.rs
@@ -115,10 +115,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         stream.push(Output::Custom(id, local));
     }
 
-    let mut compiled =
-        roto::FileTree::single_file("examples/presentation.roto")
-            .compile(rt)
-            .inspect_err(|e| eprintln!("{e}"))?;
+    let mut compiled = rt
+        .compile("examples/presentation.roto")
+        .inspect_err(|e| eprintln!("{e}"))?;
 
     let function = compiled.get_function("rib_in_pre").unwrap();
 

--- a/examples/runtime.rs
+++ b/examples/runtime.rs
@@ -1,4 +1,4 @@
-use roto::{FileTree, Runtime, Val, Verdict};
+use roto::{Runtime, Val, Verdict};
 use roto_macros::roto_method;
 
 #[derive(Clone, Copy)]
@@ -21,8 +21,8 @@ fn main() -> Result<(), roto::RotoReport> {
         bla.x
     }
 
-    let mut compiled = FileTree::single_file("examples/runtime.roto")
-        .compile(runtime)
+    let mut compiled = runtime
+        .compile("examples/runtime.roto")
         .inspect_err(|e| eprintln!("{e}"))?;
 
     let func = compiled

--- a/examples/simple.roto
+++ b/examples/simple.roto
@@ -1,6 +1,6 @@
 # checks whether ip addr is 0.0.0.0
 function is_zero(x: IpAddr) -> bool {
-    x == 0.0.0.0
+    x == 0
 }
 
 filtermap main(x: IpAddr) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,8 +48,8 @@ enum Command {
 ///  - `check`: type check a script
 ///  - `test`: run tests for a script
 ///  - `run`: run the main function of a script
-pub fn cli(rt: Runtime) {
-    match cli_inner(rt) {
+pub fn cli(rt: &Runtime) {
+    match cli_inner(&rt) {
         Ok(()) => std::process::exit(0),
         Err(err) => {
             eprintln!("{err}");
@@ -58,7 +58,7 @@ pub fn cli(rt: Runtime) {
     }
 }
 
-fn cli_inner(rt: Runtime) -> Result<(), String> {
+fn cli_inner(rt: &Runtime) -> Result<(), String> {
     let cli = Cli::parse();
 
     match &cli.command {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -314,7 +314,7 @@ pub fn codegen(
         context_description,
     };
 
-    for constant in runtime.constants.values() {
+    for constant in runtime.constants().values() {
         module.declare_constant(constant);
     }
 

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -24,7 +24,7 @@ fn compile_with_runtime(f: FileTree, runtime: Runtime) -> Compiled {
     #[cfg(feature = "logger")]
     let _ = env_logger::try_init();
 
-    let res = f.parse().and_then(|x| x.typecheck(runtime)).map(|x| {
+    let res = f.parse().and_then(|x| x.typecheck(&runtime)).map(|x| {
         let x = x.lower_to_mir().lower_to_lir();
         x.codegen()
     });

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -49,9 +49,8 @@ pub struct FileTree {
 }
 
 impl FileTree {
-    pub fn compile(self, rt: Runtime) -> Result<Compiled, RotoReport> {
+    pub fn compile(self, rt: &Runtime) -> Result<Compiled, RotoReport> {
         let checked = self.parse()?.typecheck(rt)?;
-        checked.lower_to_mir();
         let compiled = checked.lower_to_mir().lower_to_lir().codegen();
         Ok(compiled)
     }
@@ -70,7 +69,8 @@ pub enum FileSpec {
 }
 
 impl FileTree {
-    pub fn read(path: &Path) -> Self {
+    pub fn read(path: impl AsRef<Path>) -> Self {
+        let path = path.as_ref();
         if path.metadata().unwrap().file_type().is_dir() {
             Self::directory(path)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,7 @@ pub use codegen::TypedFunc;
 pub use file_tree::{FileSpec, FileTree, SourceFile};
 pub use lir::eval::Memory;
 pub use lir::value::IrValue;
-pub use pipeline::{
-    interpret, Compiled, LoweredToLir, RotoError, RotoReport,
-};
+pub use pipeline::{Compiled, LoweredToLir, RotoError, RotoReport};
 pub use roto_macros::{
     roto_function, roto_method, roto_static_method, Context,
 };

--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -270,7 +270,7 @@ pub fn eval(
     }
 
     let constants: HashMap<Identifier, &[u8]> = rt
-        .constants
+        .constants()
         .values()
         .map(|g| (g.name, g.bytes.as_ref()))
         .collect();

--- a/src/lir/lower.rs
+++ b/src/lir/lower.rs
@@ -8,6 +8,7 @@ use crate::{
     label::{LabelRef, LabelStore},
     mir,
     runtime::{
+        init_string,
         layout::{Layout, LayoutBuilder},
         RuntimeFunctionRef,
     },
@@ -665,9 +666,6 @@ impl Lowerer<'_, '_> {
                     VarKind::Explicit(identifier)
                 }
                 mir::VarKind::Tmp(x) => VarKind::Tmp(x),
-                mir::VarKind::NamedTmp(identifier, x) => {
-                    VarKind::NamedTmp(identifier, x)
-                }
             },
         }
     }
@@ -681,7 +679,7 @@ impl Lowerer<'_, '_> {
                 self.emit(Instruction::InitString {
                     to: to.clone(),
                     string: s.clone(),
-                    init_func: self.ctx.runtime.string_init_function,
+                    init_func: init_string,
                 });
 
                 to.into()

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -51,7 +51,6 @@ pub struct Var {
 pub enum VarKind {
     Explicit(Identifier),
     Tmp(usize),
-    NamedTmp(Identifier, usize),
     Return,
     Context,
 }

--- a/src/lir/print.rs
+++ b/src/lir/print.rs
@@ -60,13 +60,13 @@ impl Printable for Function {
                     )
                 }
             };
-            let _ = write!(&mut s, "  {var}: {ty}\n");
+            let _ = writeln!(&mut s, "  {var}: {ty}");
         }
 
         for b in &self.blocks {
             writeln!(s).unwrap();
             for line in b.print(&printer).lines() {
-                let _ = write!(&mut s, "  {line}\n");
+                let _ = writeln!(&mut s, "  {line}");
             }
         }
 
@@ -93,9 +93,6 @@ impl Printable for Var {
         let name = match &self.kind {
             VarKind::Explicit(name) => name.print(printer).to_string(),
             VarKind::Tmp(idx) => format!("${idx}"),
-            VarKind::NamedTmp(name, idx) => {
-                format!("${}-{idx}", name.print(printer))
-            }
             VarKind::Return => "$return".to_string(),
             VarKind::Context => "$context".to_string(),
         };

--- a/src/lir/test_eval.rs
+++ b/src/lir/test_eval.rs
@@ -1,8 +1,10 @@
 use super::{eval::Memory, value::IrValue};
-use crate::{runtime::tests::routecore_runtime, src, FileTree, LoweredToLir};
+use crate::{
+    runtime::tests::routecore_runtime, src, FileTree, LoweredToLir, Runtime,
+};
 
 #[track_caller]
-fn compile(s: FileTree) -> LoweredToLir {
+fn compile(s: FileTree, rt: &Runtime) -> LoweredToLir<'_> {
     // We run this multiple times and only want to init the
     // first time, so ignore failures.
     #[cfg(feature = "logger")]
@@ -11,10 +13,9 @@ fn compile(s: FileTree) -> LoweredToLir {
         .format_target(false)
         .try_init();
 
-    let runtime = routecore_runtime().unwrap();
     s.parse()
         .unwrap()
-        .typecheck(runtime)
+        .typecheck(rt)
         .unwrap()
         .lower_to_mir()
         .lower_to_lir()
@@ -104,7 +105,8 @@ fn accept() {
     );
 
     let mut mem = Memory::new();
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
     let pointer = mem.allocate(1);
     let ctx = IrValue::Pointer(mem.allocate(0));
     program.eval(
@@ -127,7 +129,8 @@ fn reject() {
     );
 
     let mut mem = Memory::new();
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
     let pointer = mem.allocate(1);
     let ctx = IrValue::Pointer(mem.allocate(0));
     program.eval(&mut mem, ctx, vec![IrValue::Pointer(pointer)]);
@@ -149,7 +152,8 @@ fn if_else() {
     "
     );
     let mut mem = Memory::new();
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
     let pointer = mem.allocate(1);
     let ctx = IrValue::Pointer(mem.allocate(0));
     program.eval(&mut mem, ctx, vec![IrValue::Pointer(pointer)]);
@@ -171,7 +175,8 @@ fn react_to_rx() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for i in 0..6 {
         let mut mem = Memory::new();
@@ -203,7 +208,8 @@ fn variable() {
     );
 
     let mut mem = Memory::new();
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
     let pointer = mem.allocate(1);
     let ctx = IrValue::Pointer(mem.allocate(0));
     program.eval(&mut mem, ctx, vec![IrValue::Pointer(pointer)]);
@@ -230,7 +236,8 @@ fn calling_function() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for x in 0..30 {
         let mut mem = Memory::new();
@@ -262,7 +269,8 @@ fn anonymous_record() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for x in 0..30 {
         let mut mem = Memory::new();
@@ -301,7 +309,8 @@ fn typed_record() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for x in 0..1 {
         let mut mem = Memory::new();
@@ -336,7 +345,8 @@ fn nested_record() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for x in 20..21 {
         let mut mem = Memory::new();
@@ -366,7 +376,8 @@ fn enum_values() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for (variant, expected) in [
         // IpV4 -> accepted
@@ -406,7 +417,8 @@ fn call_runtime_function() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for (value, expected) in [(5, 1), (11, 0)] {
         let mut mem = Memory::new();
@@ -436,7 +448,8 @@ fn ip_addr_method() {
     "
     );
 
-    let program = compile(s);
+    let rt = routecore_runtime().unwrap();
+    let program = compile(s, &rt);
 
     for (value, expected) in [(5, 1), (6, 0)] {
         let mut mem = Memory::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,4 @@
-use clap::Parser;
-use roto::{cli, Runtime};
-
-#[derive(Parser)]
-struct Cli {
-    #[arg(short, long)]
-    rx: Option<String>,
-    file: String,
-}
+use roto::Runtime;
 
 fn main() {
     #[cfg(feature = "logger")]
@@ -15,5 +7,7 @@ fn main() {
         .format_target(false)
         .init();
 
-    cli(Runtime::new());
+    let mut rt = Runtime::new();
+    rt.add_io_functions();
+    rt.cli();
 }

--- a/src/mir/lower.rs
+++ b/src/mir/lower.rs
@@ -1078,7 +1078,7 @@ impl<'r> Lowerer<'r> {
         name: &str,
     ) -> &RuntimeFunction {
         self.runtime
-            .functions
+            .functions()
             .iter()
             .find(|f| f.kind == kind && f.name == name)
             .unwrap()

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -32,7 +32,6 @@ pub struct Var {
 pub enum VarKind {
     Explicit(Identifier),
     Tmp(usize),
-    NamedTmp(Identifier, usize),
 }
 
 #[derive(Clone, Debug)]

--- a/src/mir/print.rs
+++ b/src/mir/print.rs
@@ -42,14 +42,14 @@ impl Printable for Function {
         for (var, ty) in &self.variables {
             let var = var.print(&printer);
             let ty = ty.display(printer.type_info);
-            let _ = write!(&mut s, "  {var}: {ty}\n");
+            let _ = writeln!(&mut s, "  {var}: {ty}");
         }
 
         let blocks = self.blocks.iter();
         for b in blocks {
             s.push('\n');
             for line in b.print(&printer).lines() {
-                let _ = write!(&mut s, "  {line}\n");
+                let _ = writeln!(&mut s, "  {line}");
             }
         }
 
@@ -208,9 +208,6 @@ impl Printable for Var {
         let name = match &self.kind {
             VarKind::Explicit(name) => name.print(printer).to_string(),
             VarKind::Tmp(idx) => format!("${idx}"),
-            VarKind::NamedTmp(name, idx) => {
-                format!("${}-{idx}", name.print(printer))
-            }
         };
         if Some(self.scope) != printer.scope {
             let f = self.scope.print(printer);

--- a/src/runtime/basic.rs
+++ b/src/runtime/basic.rs
@@ -1,0 +1,342 @@
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::Arc,
+};
+
+use inetnum::{addr::Prefix, asn::Asn};
+use roto_macros::{roto_method, roto_static_method};
+
+use crate::Runtime;
+
+macro_rules! int_docs {
+    ($t:ty) => {&{
+        #[allow(unused_comparisons)]
+        let signed = if <$t>::MIN < 0 { "signed" } else { "unsigned" };
+        let bits = <$t>::BITS;
+        let min = <$t>::MIN;
+        let max = <$t>::MAX;
+        format!("The {signed} {bits}-bit integer type\n\nThis type can represent integers from {min} up to (and including) {max}.")
+    }};
+}
+
+macro_rules! float_docs {
+    ($t:ty) => {
+        &{
+            #[allow(unused_comparisons)]
+            let bits = std::mem::size_of::<$t>();
+            format!("The {bits}-bit floating point type")
+        }
+    };
+}
+
+macro_rules! float_impl {
+    ($rt:ident, $t:ty) => {{
+        /// Returns the largest integer less than or equal to self.
+        #[roto_method($rt, $t, floor)]
+        fn floor(x: $t) -> $t {
+            x.floor()
+        }
+
+        /// Returns the smallest integer greater than or equal to self.
+        #[roto_method($rt, $t, ceil)]
+        fn ceil(x: $t) -> $t {
+            x.ceil()
+        }
+
+        /// Returns the nearest integer to self. If a value is half-way between two integers, round away from 0.0.
+        #[roto_method($rt, $t, round)]
+        fn round(x: $t) -> $t {
+            x.round()
+        }
+
+        /// Computes the absolute value of self.
+        #[roto_method($rt, $t, abs)]
+        fn abs(x: $t) -> $t {
+            x.abs()
+        }
+
+        /// Returns the square root of a number.
+        #[roto_method($rt, $t, sqrt)]
+        fn sqrt(x: $t) -> $t {
+            x.sqrt()
+        }
+
+        /// Raises a number to a floating point power.
+        #[roto_method($rt, $t, pow)]
+        fn pow(x: $t, y: $t) -> $t {
+            x.powf(y)
+        }
+
+        /// Returns true if this value is NaN.
+        #[roto_method($rt, $t, is_nan)]
+        fn is_nan(x: $t) -> bool {
+            x.is_nan()
+        }
+
+        /// Returns true if this value is positive infinity or negative infinity, and false otherwise.
+        #[roto_method($rt, $t, is_infinite)]
+        fn is_infinite(x: $t) -> bool {
+            x.is_infinite()
+        }
+
+        /// Returns true if this number is neither infinite nor NaN.
+        #[roto_method($rt, $t, is_finite)]
+        fn is_finite(x: $t) -> bool {
+            x.is_finite()
+        }
+    }};
+}
+
+impl Runtime {
+    /// A Runtime that is as empty as possible.
+    ///
+    /// This contains only type information for Roto primitives.
+    pub fn new() -> Self {
+        let mut rt = Runtime {
+            context: None,
+            types: Default::default(),
+            functions: Default::default(),
+            constants: Default::default(),
+        };
+
+        rt.register_value_type_with_name::<()>(
+            "Unit",
+            "The unit type that has just one possible value. It can be used \
+            when there is nothing meaningful to be returned.",
+        )
+        .unwrap();
+
+        rt.register_value_type::<bool>(
+            "The boolean type\n\n\
+            This type has two possible values: `true` and `false`. Several \
+            boolean operations can be used with booleans, such as `&&` (\
+            logical and), `||` (logical or) and `not`.",
+        )
+        .unwrap();
+
+        // All the integer types
+        rt.register_value_type::<u8>(int_docs!(u8)).unwrap();
+        rt.register_value_type::<u16>(int_docs!(u16)).unwrap();
+        rt.register_value_type::<u32>(int_docs!(u32)).unwrap();
+        rt.register_value_type::<u64>(int_docs!(u64)).unwrap();
+        rt.register_value_type::<i8>(int_docs!(i8)).unwrap();
+        rt.register_value_type::<i16>(int_docs!(i16)).unwrap();
+        rt.register_value_type::<i32>(int_docs!(i32)).unwrap();
+        rt.register_value_type::<i64>(int_docs!(i64)).unwrap();
+        rt.register_value_type::<f32>(float_docs!(f32)).unwrap();
+        rt.register_value_type::<f64>(float_docs!(f64)).unwrap();
+
+        rt.register_value_type::<Asn>(
+            "An ASN: an Autonomous System Number\n\
+            \n\
+            An AS number can contain a number of 32-bits and is therefore similar to a [`u32`](u32). \
+            However, AS numbers cannot be manipulated with arithmetic operations. An AS number \
+            is constructed with the `AS` prefix followed by a number.\n\
+            \n\
+            ```roto\n\
+            AS0\n\
+            AS1010\n\
+            AS4294967295\n\
+            ```\n\
+            ").unwrap();
+
+        rt.register_copy_type::<IpAddr>(
+            "An IP address\n\nCan be either IPv4 or IPv6.\n\
+            \n\
+            ```roto\n\
+            # IPv4 examples\n\
+            127.0.0.1\n\
+            0.0.0.0\n\
+            255.255.255.255\n\
+            \n\
+            # IPv6 examples\n\
+            0:0:0:0:0:0:0:1\n\
+            ::1\n\
+            ::\n\
+            ```\n\
+            ",
+        )
+        .unwrap();
+
+        rt.register_copy_type::<Prefix>(
+            "An IP address prefix: the combination of an IP address and a prefix length\n\n\
+            A prefix can be constructed with the `/` operator or with the \
+            [`Prefix.new`](Prefix.new) function. This operator takes an [`IpAddr`](IpAddr) \
+            and a [`u8`](u8) as operands.\n
+            \n\
+            ```roto\n\
+            1.1.1.0 / 8\n\
+            192.0.0.0.0 / 24\n\
+            ```\n\
+            ",
+        ).unwrap();
+
+        float_impl!(rt, f32);
+        float_impl!(rt, f64);
+
+        /// Construct a new prefix
+        ///
+        /// A prefix can also be constructed with the `/` operator.
+        ///
+        /// ```roto
+        /// Prefix.new(192.169.0.0, 16)
+        ///
+        /// # or equivalently
+        /// 192.169.0.0 / 16
+        /// ```
+        #[roto_static_method(rt, Prefix, new)]
+        fn prefix_new(ip: IpAddr, len: u8) -> Prefix {
+            Prefix::new(ip, len).unwrap()
+        }
+
+        /// Check whether two IP addresses are equal
+        ///
+        /// A more convenient but equivalent method for checking equality is via the `==` operator.
+        ///
+        /// An IPv4 address is never equal to an IPv6 address. IP addresses are considered equal if
+        /// all their bits are equal.
+        ///
+        /// ```roto
+        /// 192.0.0.0 == 192.0.0.0   # -> true
+        /// ::0 == ::0               # -> true
+        /// 192.0.0.0 == 192.0.0.1   # -> false
+        /// 0.0.0.0 == 0::0          # -> false
+        ///
+        /// # or equivalently:
+        /// 192.0.0.0.eq(192.0.0.0)  # -> true
+        /// ```
+        #[roto_method(rt, IpAddr, eq)]
+        fn ipaddr_eq(a: IpAddr, b: IpAddr) -> bool {
+            a == b
+        }
+
+        /// Returns true if this address is an IPv4 address, and false otherwise.
+        ///
+        /// ```roto
+        /// 1.1.1.1.is_ipv4() # -> true
+        /// ::.is_ipv4()      # -> false
+        /// ```
+        #[roto_method(rt, IpAddr)]
+        fn is_ipv4(ip: IpAddr) -> bool {
+            ip.is_ipv4()
+        }
+
+        /// Returns true if this address is an IPv6 address, and false otherwise.
+        ///
+        /// ```roto
+        /// 1.1.1.1.is_ipv6() # -> false
+        /// ::.is_ipv6()      # -> true
+        /// ```
+        #[roto_method(rt, IpAddr)]
+        fn is_ipv6(ip: IpAddr) -> bool {
+            ip.is_ipv6()
+        }
+
+        /// Converts this address to an IPv4 if it is an IPv4-mapped IPv6 address, otherwise it returns self as-is.
+        #[roto_method(rt, IpAddr)]
+        fn to_canonical(ip: IpAddr) -> IpAddr {
+            ip.to_canonical()
+        }
+
+        rt.register_constant(
+            "LOCALHOSTV4",
+            "The IPv4 address pointing to localhost: `127.0.0.1`",
+            IpAddr::from(Ipv4Addr::LOCALHOST),
+        )
+        .unwrap();
+
+        rt.register_constant(
+            "LOCALHOSTV6",
+            "The IPv6 address pointing to localhost: `::1`",
+            IpAddr::from(Ipv6Addr::LOCALHOST),
+        )
+        .unwrap();
+
+        rt.register_clone_type_with_name::<Arc<str>>(
+            "String",
+            "The string type",
+        )
+        .unwrap();
+
+        /// Append a string to another, creating a new string
+        ///
+        /// ```roto
+        /// "hello".append(" ").append("world") # -> "hello world"
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn append(a: Arc<str>, b: Arc<str>) -> Arc<str> {
+            format!("{a}{b}").into()
+        }
+
+        /// Check whether a string contains another string
+        ///
+        /// ```roto
+        /// "haystack".contains("hay")  # -> true
+        /// "haystack".contains("corn") # -> false
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn contains(haystack: Arc<str>, needle: Arc<str>) -> bool {
+            haystack.contains(needle.as_ref())
+        }
+
+        /// Check whether a string starts with a given prefix
+        ///
+        /// ```roto
+        /// "haystack".contains("hay")   # -> true
+        /// "haystack".contains("trees") # -> false
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn starts_with(s: Arc<str>, prefix: Arc<str>) -> bool {
+            s.starts_with(prefix.as_ref())
+        }
+
+        /// Check whether a string end with a given suffix
+        ///
+        /// ```roto
+        /// "haystack".contains("stack") # -> true
+        /// "haystack".contains("black") # -> false
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn ends_with(s: Arc<str>, suffix: Arc<str>) -> bool {
+            s.ends_with(suffix.as_ref())
+        }
+
+        /// Create a new string with all characters converted to lowercase
+        ///
+        /// ```roto
+        /// "LOUD".to_lowercase() # -> "loud"
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn to_lowercase(s: Arc<str>) -> Arc<str> {
+            s.to_lowercase().into()
+        }
+
+        /// Create a new string with all characters converted to lowercase
+        ///
+        /// ```roto
+        /// "quiet".to_uppercase() # -> "QUIET"
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn to_uppercase(s: Arc<str>) -> Arc<str> {
+            s.to_uppercase().into()
+        }
+
+        /// Repeat a string `n` times and join them
+        ///
+        /// ```roto
+        /// "ha".repeat(6) # -> "hahahahahaha"
+        /// ```
+        #[roto_method(rt, Arc<str>)]
+        fn repeat(s: Arc<str>, n: u32) -> Arc<str> {
+            s.repeat(n as usize).into()
+        }
+
+        /// Check for string equality
+        #[roto_method(rt, Arc<str>)]
+        fn eq(s: Arc<str>, other: Arc<str>) -> bool {
+            s == other
+        }
+
+        rt
+    }
+}

--- a/src/runtime/docs.rs
+++ b/src/runtime/docs.rs
@@ -1,0 +1,155 @@
+use std::any::TypeId;
+
+use crate::{
+    runtime::{
+        context::ContextDescription, FunctionKind, RuntimeConstant,
+        RuntimeFunction,
+    },
+    Runtime, RuntimeType,
+};
+
+impl Runtime {
+    fn print_ty(&self, ty: TypeId) -> &str {
+        let ty = self.get_runtime_type(ty).unwrap();
+        ty.name.as_ref()
+    }
+
+    fn print_function(&self, f: &RuntimeFunction) {
+        let RuntimeFunction {
+            name,
+            description,
+            kind,
+            id: _,
+            docstring,
+            argument_names,
+        } = f;
+
+        let params = description
+            .parameter_types()
+            .iter()
+            .map(|ty| self.print_ty(*ty))
+            .collect::<Vec<_>>();
+
+        let ret = self.print_ty(description.return_type());
+
+        let mut argument_names = argument_names.iter();
+        let mut params = params.iter();
+        let receiver = match *kind {
+            FunctionKind::Method(_) => {
+                // Discard the name of the receiver from the arguments
+                let _ = argument_names.next();
+                format!("{}.", params.next().unwrap())
+            }
+            FunctionKind::StaticMethod(id) => {
+                format!("{}.", self.print_ty(id))
+            }
+            FunctionKind::Free => "".into(),
+        };
+
+        let mut parameter_string = String::new();
+        let mut first = true;
+        for param in params {
+            if !first {
+                parameter_string.push_str(", ");
+            }
+            let name = argument_names.next().map_or("_", |v| v);
+            parameter_string.push_str(name);
+            parameter_string.push_str(": ");
+            parameter_string.push_str(param);
+            first = false;
+        }
+
+        let kind = match kind {
+            FunctionKind::Free => "function",
+            FunctionKind::Method(_) => "method",
+            FunctionKind::StaticMethod(_) => "static_method",
+        };
+        println!(
+            "````{{roto:{kind}}} {receiver}{name}({parameter_string}) -> {ret}"
+        );
+        for line in docstring.lines() {
+            println!("{line}")
+        }
+        println!("````");
+        println!();
+    }
+
+    pub fn print_documentation(&self) {
+        println!("# Standard Library");
+        println!();
+
+        for f in &self.functions {
+            if f.kind != FunctionKind::Free {
+                continue;
+            }
+            self.print_function(f);
+        }
+
+        if let Some(ContextDescription {
+            type_id: _,
+            type_name: _,
+            fields,
+        }) = &self.context
+        {
+            for crate::ContextField {
+                name,
+                offset: _,
+                type_name: _,
+                type_id,
+                docstring,
+            } in fields
+            {
+                println!(
+                    "`````{{roto:context}} {name}: {}",
+                    self.print_ty(*type_id)
+                );
+                for line in docstring.lines() {
+                    println!("{line}");
+                }
+                println!("`````\n");
+            }
+        }
+
+        for RuntimeConstant {
+            name,
+            ty,
+            docstring,
+            ..
+        } in self.constants.values()
+        {
+            println!("`````{{roto:constant}} {name}: {}", self.print_ty(*ty));
+            for line in docstring.lines() {
+                println!("{line}");
+            }
+            println!("`````\n");
+        }
+
+        for RuntimeType {
+            name,
+            type_id,
+            docstring,
+            ..
+        } in &self.types
+        {
+            println!("`````{{roto:type}} {name}");
+            for line in docstring.lines() {
+                println!("{line}");
+            }
+            println!();
+
+            for f in &self.functions {
+                let id = match f.kind {
+                    FunctionKind::Free => continue,
+                    FunctionKind::Method(id)
+                    | FunctionKind::StaticMethod(id) => id,
+                };
+                if id != *type_id {
+                    continue;
+                }
+                self.print_function(f);
+            }
+
+            println!("`````\n")
+        }
+    }
+}

--- a/src/runtime/func.rs
+++ b/src/runtime/func.rs
@@ -2,8 +2,6 @@ use std::any::TypeId;
 
 use crate::codegen::check::{RotoFunc, RustIrFunction};
 
-use super::ty::TypeRegistry;
-
 pub struct Func<F: RotoFunc> {
     wrapper: <F as RotoFunc>::RustWrapper,
     docstring: &'static str,
@@ -20,6 +18,10 @@ impl<F: RotoFunc> Func<F> {
     ///
     /// Use the [`roto_function`], [`roto_method`] and [`roto_static_method`]
     /// macros to be sure of that.
+    ///
+    /// [`roto_function`]: crate::roto_function
+    /// [`roto_method`]: crate::roto_method
+    /// [`roto_static_method`]: crate::roto_static_method
     pub unsafe fn new(
         wrapper: <F as RotoFunc>::RustWrapper,
         docstring: &'static str,
@@ -40,12 +42,9 @@ impl<F: RotoFunc> Func<F> {
         self.argument_names
     }
 
-    pub(crate) fn to_function_description(
-        &self,
-        type_registry: &mut TypeRegistry,
-    ) -> FunctionDescription {
-        let parameter_types = F::parameter_types(type_registry);
-        let return_type = F::return_type(type_registry);
+    pub(crate) fn to_function_description(&self) -> FunctionDescription {
+        let parameter_types = F::parameter_types();
+        let return_type = F::return_type();
         let pointer = F::ptr(&self.wrapper);
         let ir_function = F::ir_function(&self.wrapper);
 

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use roto_macros::roto_function;
+
+use crate::Runtime;
+
+impl Runtime {
+    pub fn add_io_functions(&mut self) {
+        let rt = self;
+
+        #[roto_function(rt)]
+        fn print(s: Arc<str>) {
+            println!("{s}");
+        }
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,34 +1,10 @@
 //! Runtime definition for Roto
-//!
-//! Roto is an embedded language, therefore, it must be hooked up to the
-//! outside world to do anything useful besides pure computation. This
-//! connection is provided by the [`Runtime`], which exposes types, methods
-//! and functions to Roto.
-//!
-//! Roto can run in different [`Runtime`]s, depending on the situation.
-//! Extending the default [`Runtime`] is the primary way to extend the
-//! capabilities of Roto.
-//!
-//! > **Note about safety**: You should be careful with the functions
-//! > provided to Roto. If the types of functions and methods in Roto do
-//! > not match up with the types in Rust then the Roto script will probably
-//! > be unsound. That being said, FFI is just unsafe in general.
-//!
-//! TODO: Figure out some macro to automatically derive the correct
-//! signature.
-//!
-//! A runtime function needs a bit of information:
-//!  - The number of arguments
-//!  - The type of the arguments.
-//!  - The return type
-//!  - Whether or not a type should be copied is not just up to the type
-//!    but also up to the method, making this whole thing more complicated.
-//!
-//! We might need polymorphism over the number of arguments.
-//! The IR needs typed variables to do this correctly.
 
+mod basic;
 pub mod context;
+mod docs;
 pub mod func;
+mod io;
 pub mod layout;
 pub mod optional;
 pub mod ty;
@@ -38,56 +14,115 @@ pub mod verdict;
 #[cfg(test)]
 pub mod tests;
 
-use core::{slice, str};
 use std::{
     any::{type_name, TypeId},
     collections::HashMap,
-    fmt::Display,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    ptr,
+    path::Path,
+    ptr, slice, str,
     sync::Arc,
 };
 
 use context::ContextDescription;
 use func::{Func, FunctionDescription};
-use inetnum::{addr::Prefix, asn::Asn};
 use layout::Layout;
-use roto_macros::{roto_method, roto_static_method};
-use ty::{Ty, TypeDescription, TypeRegistry};
+use ty::TypeDescription;
 
 use crate::{
     ast::Identifier,
     codegen::check::RotoFunc,
     parser::token::{Lexer, Token},
-    Context,
+    runtime::ty::{Ty, TypeRegistry},
+    Compiled, Context, FileTree, RotoReport,
 };
 
 /// Provides the types and functions that Roto can access via FFI
 ///
-/// Even some types that can be written as literals should be provided here.
-/// The idea here is that Roto can be used with different representations
-/// of these types in different applications. The type checker will yield an
-/// error if a literal is provided for an undeclared type.
+/// Roto is an embedded language, therefore, it must be hooked up to the
+/// outside world to do anything useful besides pure computation. This
+/// connection is provided by the [`Runtime`], which exposes types, methods
+/// and functions to Roto.
+///
+/// Roto can run in different [`Runtime`]s, depending on the situation.
+/// Extending the default [`Runtime`] is the primary way to extend the
+/// capabilities of Roto.
+///
+/// ## Compiling a script
+///
+/// - [`Runtime::compile`]
+///
+/// ## Registering Types
+///
+/// - [`Runtime::register_copy_type`]
+/// - [`Runtime::register_clone_type`]
+/// - [`Runtime::register_copy_type_with_name`]
+/// - [`Runtime::register_clone_type_with_name`]
+///
+/// ## Registering functions and methods
+///
+/// - [`Runtime::register_function`]
+/// - [`Runtime::register_method`]
+/// - [`Runtime::register_static_method`]
+///
+/// ## Registering contstants
+///
+/// - [`Runtime::register_constant`]
+///
+/// ## Registering context type
+///
+/// - [`Runtime::register_context_type`]
+///
+/// ## Printing documentation
+///
+/// - [`Runtime::print_documentation`]
 #[derive(Clone)]
 pub struct Runtime {
-    pub context: Option<ContextDescription>,
-    pub runtime_types: Vec<RuntimeType>,
-    pub functions: Vec<RuntimeFunction>,
-    pub constants: HashMap<Identifier, RuntimeConstant>,
-    pub type_registry: TypeRegistry,
-    pub string_init_function:
-        unsafe extern "C" fn(*mut Arc<str>, *mut u8, u32),
+    context: Option<ContextDescription>,
+    types: Vec<RuntimeType>,
+    functions: Vec<RuntimeFunction>,
+    constants: HashMap<Identifier, RuntimeConstant>,
+}
+
+impl Runtime {
+    pub fn compile(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<Compiled, RotoReport> {
+        FileTree::read(path).compile(self)
+    }
+}
+
+/// Inspecting the [`Runtime`]
+impl Runtime {
+    /// Get the context type, if any.
+    pub fn context(&self) -> &Option<ContextDescription> {
+        &self.context
+    }
+
+    /// Get the registered types.
+    pub fn types(&self) -> &[RuntimeType] {
+        &self.types
+    }
+
+    /// Get the registered functions.
+    pub fn functions(&self) -> &[RuntimeFunction] {
+        &self.functions
+    }
+
+    /// Get the registered constants.
+    pub fn constants(&self) -> &HashMap<Identifier, RuntimeConstant> {
+        &self.constants
+    }
 }
 
 #[derive(Clone, Debug)]
 pub enum Movability {
-    // This type is passed by value, only available for built-in types.
+    /// This type is passed by value, only available for built-in types.
     Value,
 
-    // This type can be copied without calling clone and drop.
+    /// This type can be copied without calling clone and drop.
     Copy,
 
-    // This type needs a clone and drop function.
+    /// This type needs a clone and drop function.
     CloneDrop(CloneDrop),
 }
 
@@ -111,12 +146,6 @@ unsafe extern "C" fn extern_clone<T: Clone>(from: *const (), to: *mut ()) {
 unsafe extern "C" fn extern_drop<T>(x: *mut ()) {
     let x = x as *mut T;
     unsafe { std::ptr::drop_in_place(x) };
-}
-
-unsafe extern "C" fn init_string(s: *mut Arc<str>, data: *mut u8, len: u32) {
-    let slice = unsafe { slice::from_raw_parts(data, len as usize) };
-    let str = unsafe { str::from_utf8_unchecked(slice) };
-    unsafe { ptr::write(s, str.into()) };
 }
 
 #[derive(Clone, Debug)]
@@ -167,26 +196,26 @@ pub enum FunctionKind {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeFunction {
     /// Name that the function can be referenced by
-    pub name: String,
+    pub(crate) name: String,
 
     /// Description of the signature of the function
-    pub description: FunctionDescription,
+    pub(crate) description: FunctionDescription,
 
     /// Whether it's a free function, method or a static method
-    pub kind: FunctionKind,
+    pub(crate) kind: FunctionKind,
 
     /// Unique identifier for this function
-    pub id: usize,
+    pub(crate) id: usize,
 
-    pub docstring: &'static str,
+    pub(crate) docstring: &'static str,
 
-    pub argument_names: &'static [&'static str],
+    pub(crate) argument_names: &'static [&'static str],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RuntimeFunctionRef(usize);
 
-impl Display for RuntimeFunctionRef {
+impl std::fmt::Display for RuntimeFunctionRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
@@ -198,7 +227,7 @@ impl RuntimeFunction {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RuntimeConstant {
     pub name: Identifier,
     pub ty: TypeId,
@@ -207,7 +236,10 @@ pub struct RuntimeConstant {
 }
 
 impl Runtime {
-    pub fn get_function(&self, f: RuntimeFunctionRef) -> &RuntimeFunction {
+    pub(crate) fn get_function(
+        &self,
+        f: RuntimeFunctionRef,
+    ) -> &RuntimeFunction {
         &self.functions[f.0]
     }
 
@@ -325,9 +357,8 @@ impl Runtime {
     ) -> Result<(), String> {
         Self::check_name(name)?;
 
-        if let Some(ty) = self.runtime_types.iter().find(|ty| ty.name == name)
-        {
-            let name = self.type_registry.get(ty.type_id).unwrap().rust_name;
+        if let Some(ty) = self.types.iter().find(|ty| ty.name == name) {
+            let name = TypeRegistry::get(ty.type_id).unwrap().rust_name;
             return Err(format!(
                 "Type with name {name} already registered.\n\
                 Previously registered type: {}\n\
@@ -337,10 +368,8 @@ impl Runtime {
             ));
         }
 
-        if let Some(ty) = self
-            .runtime_types
-            .iter()
-            .find(|ty| ty.type_id == TypeId::of::<T>())
+        if let Some(ty) =
+            self.types.iter().find(|ty| ty.type_id == TypeId::of::<T>())
         {
             return Err(format!(
                 "Type {} is already registered under a different name: {}`",
@@ -349,8 +378,8 @@ impl Runtime {
             ));
         }
 
-        self.type_registry.store::<T>(ty::TypeDescription::Leaf);
-        self.runtime_types.push(RuntimeType {
+        TypeRegistry::store::<T>(ty::TypeDescription::Leaf);
+        self.types.push(RuntimeType {
             name: name.into(),
             type_id: TypeId::of::<T>(),
             movability,
@@ -372,7 +401,7 @@ impl Runtime {
         // The context type likely hasn't been registered yet in the
         // type registry, so we do that, so that we can reason about
         // it more easily and make better error messages.
-        self.type_registry.store::<Ctx>(TypeDescription::Leaf);
+        TypeRegistry::store::<Ctx>(TypeDescription::Leaf);
 
         // All fields in the context must be known because they'll
         // be accessible from Roto.
@@ -392,7 +421,7 @@ impl Runtime {
     ) -> Result<(), String> {
         let docstring = f.docstring();
         let argument_names = f.argument_names();
-        let description = f.to_function_description(&mut self.type_registry);
+        let description = f.to_function_description();
         let name = name.into();
 
         Self::check_name(&name)?;
@@ -417,7 +446,7 @@ impl Runtime {
     ) -> Result<(), String> {
         let docstring = f.docstring();
         let argument_names = f.argument_names();
-        let description = f.to_function_description(&mut self.type_registry);
+        let description = f.to_function_description();
         let name = name.into();
 
         Self::check_name(&name)?;
@@ -429,7 +458,7 @@ impl Runtime {
 
         // `to_function_description` already checks the validity of the types
         // so unwrap is ok.
-        let ty = self.type_registry.get(*first).unwrap();
+        let ty = TypeRegistry::get(*first).unwrap();
 
         let type_id = match ty.description {
             TypeDescription::Leaf => ty.type_id,
@@ -469,7 +498,7 @@ impl Runtime {
     ) -> Result<(), String> {
         let docstring = f.docstring();
         let argument_names = f.argument_names();
-        let description = f.to_function_description(&mut self.type_registry);
+        let description = f.to_function_description();
         let name = name.into();
 
         Self::check_name(&name)?;
@@ -518,20 +547,17 @@ impl Runtime {
         Ok(())
     }
 
-    pub fn iter_constants(
+    pub(crate) fn get_runtime_type(
         &self,
-    ) -> impl Iterator<Item = (Identifier, TypeId)> + '_ {
-        self.constants.values().map(|g| (g.name, g.ty))
-    }
-
-    pub fn get_runtime_type(&self, id: TypeId) -> Option<&RuntimeType> {
-        let ty = self.type_registry.get(id)?;
+        id: TypeId,
+    ) -> Option<&RuntimeType> {
+        let ty = TypeRegistry::get(id)?;
         let id = match ty.description {
             TypeDescription::Leaf => id,
             TypeDescription::Val(id) => id,
             _ => panic!(),
         };
-        self.runtime_types.iter().find(|ty| ty.type_id == id)
+        self.types.iter().find(|ty| ty.type_id == id)
     }
 
     fn check_name(name: &str) -> Result<(), String> {
@@ -563,7 +589,7 @@ impl Runtime {
     ) -> Result<(), String> {
         let check_type = |id: &TypeId| {
             self.get_runtime_type(*id).ok_or_else(|| {
-                let ty = self.type_registry.get(*id).unwrap();
+                let ty = TypeRegistry::get(*id).unwrap();
                 format!(
                     "Registered a function using an unregistered type: `{}`",
                     ty.rust_name
@@ -573,11 +599,11 @@ impl Runtime {
 
         // TODO: This check needs to be done recursively
         for type_id in description.parameter_types() {
-            let ty = self.type_registry.get(*type_id).unwrap();
+            let ty = TypeRegistry::get(*type_id).unwrap();
             let runtime_ty = check_type(type_id)?;
             if let Movability::Value = runtime_ty.movability {
                 if !matches!(ty.description, TypeDescription::Leaf) {
-                    let ty = self.type_registry.get(ty.type_id).unwrap();
+                    let ty = TypeRegistry::get(ty.type_id).unwrap();
                     return Err(format!(
                         "Type `{}` should be passed by value. Try removing the `Val<T>` around `T`",
                         ty.rust_name,
@@ -589,168 +615,19 @@ impl Runtime {
         Ok(())
     }
 
-    fn print_ty(&self, ty: TypeId) -> &str {
-        let ty = self.get_runtime_type(ty).unwrap();
-        ty.name.as_ref()
-    }
-
-    fn print_function(&self, f: &RuntimeFunction) {
-        let RuntimeFunction {
-            name,
-            description,
-            kind,
-            id: _,
-            docstring,
-            argument_names,
-        } = f;
-        let mut params = description
-            .parameter_types()
-            .iter()
-            .map(|ty| self.print_ty(*ty))
-            .collect::<Vec<_>>();
-        let ret = params.remove(0);
-
-        let mut argument_names = argument_names.iter();
-        let mut params = params.iter();
-        let receiver = match *kind {
-            FunctionKind::Method(_) => {
-                // Discard the name of the receiver from the arguments
-                let _ = argument_names.next();
-                format!("{}.", params.next().unwrap())
-            }
-            FunctionKind::StaticMethod(id) => {
-                format!("{}.", self.print_ty(id))
-            }
-            FunctionKind::Free => "".into(),
-        };
-
-        let mut parameter_string = String::new();
-        let mut first = true;
-        for param in params {
-            if !first {
-                parameter_string.push_str(", ");
-            }
-            let name = argument_names.next().map_or("_", |v| v);
-            parameter_string.push_str(name);
-            parameter_string.push_str(": ");
-            parameter_string.push_str(param);
-            first = false;
-        }
-
-        let kind = match kind {
-            FunctionKind::Free => "function",
-            FunctionKind::Method(_) => "method",
-            FunctionKind::StaticMethod(_) => "static_method",
-        };
-        println!(
-            "````{{roto:{kind}}} {receiver}{name}({parameter_string}) -> {ret}"
-        );
-        for line in docstring.lines() {
-            println!("{line}")
-        }
-        println!("````");
-        println!();
-    }
-
-    pub fn print_documentation(&self) {
-        println!("# Standard Library");
-        println!();
-
-        for f in &self.functions {
-            if f.kind != FunctionKind::Free {
-                continue;
-            }
-            self.print_function(f);
-        }
-
-        if let Some(ContextDescription {
-            type_id: _,
-            type_name: _,
-            fields,
-        }) = &self.context
-        {
-            for crate::ContextField {
-                name,
-                offset: _,
-                type_name: _,
-                type_id,
-                docstring,
-            } in fields
-            {
-                println!(
-                    "`````{{roto:context}} {name}: {}",
-                    self.print_ty(*type_id)
-                );
-                for line in docstring.lines() {
-                    println!("{line}");
-                }
-                println!("`````\n");
-            }
-        }
-
-        for RuntimeConstant {
-            name,
-            ty,
-            docstring,
-            ..
-        } in self.constants.values()
-        {
-            println!("`````{{roto:constant}} {name}: {}", self.print_ty(*ty));
-            for line in docstring.lines() {
-                println!("{line}");
-            }
-            println!("`````\n");
-        }
-
-        for RuntimeType {
-            name,
-            type_id,
-            docstring,
-            ..
-        } in &self.runtime_types
-        {
-            println!("`````{{roto:type}} {name}");
-            for line in docstring.lines() {
-                println!("{line}");
-            }
-            println!();
-
-            for f in &self.functions {
-                let id = match f.kind {
-                    FunctionKind::Free => continue,
-                    FunctionKind::Method(id)
-                    | FunctionKind::StaticMethod(id) => id,
-                };
-                if id != *type_id {
-                    continue;
-                }
-                self.print_function(f);
-            }
-
-            println!("`````\n")
+    fn find_type(&self, id: TypeId, name: &str) -> Result<&Ty, String> {
+        match TypeRegistry::get(id) {
+            Some(t) => Ok(t),
+            None => Err(format!(
+                "Type `{name}` has not been registered and cannot be inspected by Roto"
+            )),
         }
     }
-}
 
-macro_rules! int_docs {
-    ($t:ty) => {&{
-        #[allow(unused_comparisons)]
-        let signed = if <$t>::MIN < 0 { "signed" } else { "unsigned" };
-        let bits = <$t>::BITS;
-        let min = <$t>::MIN;
-        let max = <$t>::MAX;
-        format!("The {signed} {bits}-bit integer type\n\nThis type can represent integers from {min} up to (and including) {max}.")
-    }};
-}
-
-macro_rules! float_docs {
-    ($t:ty) => {
-        &{
-            #[allow(unused_comparisons)]
-            let bits = std::mem::size_of::<$t>();
-            format!("The {bits}-bit floating point type")
-        }
-    };
+    #[cfg(feature = "cli")]
+    pub fn cli(&self) {
+        crate::cli(self)
+    }
 }
 
 impl Default for Runtime {
@@ -759,329 +636,12 @@ impl Default for Runtime {
     }
 }
 
-macro_rules! float_impl {
-    ($rt:ident, $t:ty) => {{
-        /// Returns the largest integer less than or equal to self.
-        #[roto_method($rt, $t, floor)]
-        fn floor(x: $t) -> $t {
-            x.floor()
-        }
-
-        /// Returns the smallest integer greater than or equal to self.
-        #[roto_method($rt, $t, ceil)]
-        fn ceil(x: $t) -> $t {
-            x.ceil()
-        }
-
-        /// Returns the nearest integer to self. If a value is half-way between two integers, round away from 0.0.
-        #[roto_method($rt, $t, round)]
-        fn round(x: $t) -> $t {
-            x.round()
-        }
-
-        /// Computes the absolute value of self.
-        #[roto_method($rt, $t, abs)]
-        fn abs(x: $t) -> $t {
-            x.abs()
-        }
-
-        /// Returns the square root of a number.
-        #[roto_method($rt, $t, sqrt)]
-        fn sqrt(x: $t) -> $t {
-            x.sqrt()
-        }
-
-        /// Raises a number to a floating point power.
-        #[roto_method($rt, $t, pow)]
-        fn pow(x: $t, y: $t) -> $t {
-            x.powf(y)
-        }
-
-        /// Returns true if this value is NaN.
-        #[roto_method($rt, $t, is_nan)]
-        fn is_nan(x: $t) -> bool {
-            x.is_nan()
-        }
-
-        /// Returns true if this value is positive infinity or negative infinity, and false otherwise.
-        #[roto_method($rt, $t, is_infinite)]
-        fn is_infinite(x: $t) -> bool {
-            x.is_infinite()
-        }
-
-        /// Returns true if this number is neither infinite nor NaN.
-        #[roto_method($rt, $t, is_finite)]
-        fn is_finite(x: $t) -> bool {
-            x.is_finite()
-        }
-    }};
-}
-
-impl Runtime {
-    /// A Runtime that is as empty as possible.
-    ///
-    /// This contains only type information for Roto primitives.
-    pub fn new() -> Self {
-        let mut rt = Runtime {
-            context: None,
-            runtime_types: Default::default(),
-            functions: Default::default(),
-            type_registry: Default::default(),
-            constants: Default::default(),
-            string_init_function: init_string as _,
-        };
-
-        rt.register_value_type_with_name::<()>(
-            "Unit",
-            "The unit type that has just one possible value. It can be used \
-            when there is nothing meaningful to be returned.",
-        )
-        .unwrap();
-
-        rt.register_value_type::<bool>(
-            "The boolean type\n\n\
-            This type has two possible values: `true` and `false`. Several \
-            boolean operations can be used with booleans, such as `&&` (\
-            logical and), `||` (logical or) and `not`.",
-        )
-        .unwrap();
-
-        // All the integer types
-        rt.register_value_type::<u8>(int_docs!(u8)).unwrap();
-        rt.register_value_type::<u16>(int_docs!(u16)).unwrap();
-        rt.register_value_type::<u32>(int_docs!(u32)).unwrap();
-        rt.register_value_type::<u64>(int_docs!(u64)).unwrap();
-        rt.register_value_type::<i8>(int_docs!(i8)).unwrap();
-        rt.register_value_type::<i16>(int_docs!(i16)).unwrap();
-        rt.register_value_type::<i32>(int_docs!(i32)).unwrap();
-        rt.register_value_type::<i64>(int_docs!(i64)).unwrap();
-        rt.register_value_type::<f32>(float_docs!(f32)).unwrap();
-        rt.register_value_type::<f64>(float_docs!(f64)).unwrap();
-
-        rt.register_value_type::<Asn>(
-            "An ASN: an Autonomous System Number\n\
-            \n\
-            An AS number can contain a number of 32-bits and is therefore similar to a [`u32`](u32). \
-            However, AS numbers cannot be manipulated with arithmetic operations. An AS number \
-            is constructed with the `AS` prefix followed by a number.\n\
-            \n\
-            ```roto\n\
-            AS0\n\
-            AS1010\n\
-            AS4294967295\n\
-            ```\n\
-            ").unwrap();
-
-        rt.register_copy_type::<IpAddr>(
-            "An IP address\n\nCan be either IPv4 or IPv6.\n\
-            \n\
-            ```roto\n\
-            # IPv4 examples\n\
-            127.0.0.1\n\
-            0.0.0.0\n\
-            255.255.255.255\n\
-            \n\
-            # IPv6 examples\n\
-            0:0:0:0:0:0:0:1\n\
-            ::1\n\
-            ::\n\
-            ```\n\
-            ",
-        )
-        .unwrap();
-
-        rt.register_copy_type::<Prefix>(
-            "An IP address prefix: the combination of an IP address and a prefix length\n\n\
-            A prefix can be constructed with the `/` operator or with the \
-            [`Prefix.new`](Prefix.new) function. This operator takes an [`IpAddr`](IpAddr) \
-            and a [`u8`](u8) as operands.\n
-            \n\
-            ```roto\n\
-            1.1.1.0 / 8\n\
-            192.0.0.0.0 / 24\n\
-            ```\n\
-            ",
-        ).unwrap();
-
-        float_impl!(rt, f32);
-        float_impl!(rt, f64);
-
-        /// Construct a new prefix
-        ///
-        /// A prefix can also be constructed with the `/` operator.
-        ///
-        /// ```roto
-        /// Prefix.new(192.169.0.0, 16)
-        ///
-        /// # or equivalently
-        /// 192.169.0.0 / 16
-        /// ```
-        #[roto_static_method(rt, Prefix, new)]
-        fn prefix_new(ip: IpAddr, len: u8) -> Prefix {
-            dbg!();
-            dbg!(ip, len);
-            Prefix::new(ip, len).unwrap()
-        }
-
-        /// Check whether two IP addresses are equal
-        ///
-        /// A more convenient but equivalent method for checking equality is via the `==` operator.
-        ///
-        /// An IPv4 address is never equal to an IPv6 address. IP addresses are considered equal if
-        /// all their bits are equal.
-        ///
-        /// ```roto
-        /// 192.0.0.0 == 192.0.0.0   # -> true
-        /// ::0 == ::0               # -> true
-        /// 192.0.0.0 == 192.0.0.1   # -> false
-        /// 0.0.0.0 == 0::0          # -> false
-        ///
-        /// # or equivalently:
-        /// 192.0.0.0.eq(192.0.0.0)  # -> true
-        /// ```
-        #[roto_method(rt, IpAddr, eq)]
-        fn ipaddr_eq(a: IpAddr, b: IpAddr) -> bool {
-            a == b
-        }
-
-        /// Returns true if this address is an IPv4 address, and false otherwise.
-        ///
-        /// ```roto
-        /// 1.1.1.1.is_ipv4() # -> true
-        /// ::.is_ipv4()      # -> false
-        /// ```
-        #[roto_method(rt, IpAddr)]
-        fn is_ipv4(ip: IpAddr) -> bool {
-            ip.is_ipv4()
-        }
-
-        /// Returns true if this address is an IPv6 address, and false otherwise.
-        ///
-        /// ```roto
-        /// 1.1.1.1.is_ipv6() # -> false
-        /// ::.is_ipv6()      # -> true
-        /// ```
-        #[roto_method(rt, IpAddr)]
-        fn is_ipv6(ip: IpAddr) -> bool {
-            ip.is_ipv6()
-        }
-
-        /// Converts this address to an IPv4 if it is an IPv4-mapped IPv6 address, otherwise it returns self as-is.
-        #[roto_method(rt, IpAddr)]
-        fn to_canonical(ip: IpAddr) -> IpAddr {
-            ip.to_canonical()
-        }
-
-        rt.register_constant(
-            "LOCALHOSTV4",
-            "The IPv4 address pointing to localhost: `127.0.0.1`",
-            IpAddr::from(Ipv4Addr::LOCALHOST),
-        )
-        .unwrap();
-
-        rt.register_constant(
-            "LOCALHOSTV6",
-            "The IPv6 address pointing to localhost: `::1`",
-            IpAddr::from(Ipv6Addr::LOCALHOST),
-        )
-        .unwrap();
-
-        rt.register_clone_type_with_name::<Arc<str>>(
-            "String",
-            "The string type",
-        )
-        .unwrap();
-
-        /// Append a string to another, creating a new string
-        ///
-        /// ```roto
-        /// "hello".append(" ").append("world") # -> "hello world"
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn append(a: Arc<str>, b: Arc<str>) -> Arc<str> {
-            format!("{a}{b}").into()
-        }
-
-        /// Check whether a string contains another string
-        ///
-        /// ```roto
-        /// "haystack".contains("hay")  # -> true
-        /// "haystack".contains("corn") # -> false
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn contains(haystack: Arc<str>, needle: Arc<str>) -> bool {
-            haystack.contains(needle.as_ref())
-        }
-
-        /// Check whether a string starts with a given prefix
-        ///
-        /// ```roto
-        /// "haystack".contains("hay")   # -> true
-        /// "haystack".contains("trees") # -> false
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn starts_with(s: Arc<str>, prefix: Arc<str>) -> bool {
-            s.starts_with(prefix.as_ref())
-        }
-
-        /// Check whether a string end with a given suffix
-        ///
-        /// ```roto
-        /// "haystack".contains("stack") # -> true
-        /// "haystack".contains("black") # -> false
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn ends_with(s: Arc<str>, suffix: Arc<str>) -> bool {
-            s.ends_with(suffix.as_ref())
-        }
-
-        /// Create a new string with all characters converted to lowercase
-        ///
-        /// ```roto
-        /// "LOUD".to_lowercase() # -> "loud"
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn to_lowercase(s: Arc<str>) -> Arc<str> {
-            s.to_lowercase().into()
-        }
-
-        /// Create a new string with all characters converted to lowercase
-        ///
-        /// ```roto
-        /// "quiet".to_uppercase() # -> "QUIET"
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn to_uppercase(s: Arc<str>) -> Arc<str> {
-            s.to_uppercase().into()
-        }
-
-        /// Repeat a string `n` times and join them
-        ///
-        /// ```roto
-        /// "ha".repeat(6) # -> "hahahahahaha"
-        /// ```
-        #[roto_method(rt, Arc<str>)]
-        fn repeat(s: Arc<str>, n: u32) -> Arc<str> {
-            s.repeat(n as usize).into()
-        }
-
-        /// Check for string equality
-        #[roto_method(rt, Arc<str>)]
-        fn eq(s: Arc<str>, other: Arc<str>) -> bool {
-            s == other
-        }
-
-        rt
-    }
-
-    // We might not use this, but let's keep it around for now (as of 27/8/2024)
-    #[allow(unused)]
-    fn find_type(&self, id: TypeId, name: &str) -> Result<&Ty, String> {
-        match self.type_registry.get(id) {
-            Some(t) => Ok(t),
-            None => Err(format!(
-                "Type `{name}` has not been registered and cannot be inspected by Roto"
-            )),
-        }
-    }
+pub unsafe extern "C" fn init_string(
+    s: *mut Arc<str>,
+    data: *mut u8,
+    len: u32,
+) {
+    let slice = unsafe { slice::from_raw_parts(data, len as usize) };
+    let str = unsafe { std::str::from_utf8_unchecked(slice) };
+    unsafe { ptr::write(s, str.into()) };
 }

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -39,7 +39,7 @@ pub fn routecore_runtime() -> Result<Runtime, String> {
 pub fn default_runtime() {
     let rt = routecore_runtime().unwrap();
 
-    let names: Vec<_> = rt.runtime_types.iter().map(|ty| &ty.name).collect();
+    let names: Vec<_> = rt.types.iter().map(|ty| &ty.name).collect();
     assert_eq!(
         names,
         &[

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -25,7 +25,7 @@ fn typecheck_with_runtime(
 
     // Unwrap on parse because a parse error in this file is never correct.
     // We only want to test for type errors.
-    if let Err(e) = res.typecheck(rt) {
+    if let Err(e) = res.typecheck(&rt) {
         println!("{e}");
         Err(e)
     } else {

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -9,7 +9,7 @@ fn parse_errors() {
 
         let relative_path = path.strip_prefix(&root).unwrap();
         let file_tree = FileTree::read(relative_path);
-        let res = file_tree.compile(runtime);
+        let res = file_tree.compile(&runtime);
         let Err(e) = res else {
             panic!("should not succeed");
         };
@@ -27,7 +27,7 @@ fn type_errors() {
 
         let relative_path = path.strip_prefix(&root).unwrap();
         let file_tree = FileTree::read(relative_path);
-        let res = file_tree.compile(runtime);
+        let res = file_tree.compile(&runtime);
         let Err(e) = res else {
             panic!("should not succeed");
         };


### PR DESCRIPTION
These changes are based on the the kinds of examples I wanted to write for the documentation.

- `Runtime` now as a compile method that takes `impl AsRef<Path>`. So it's no longer necessary to first create a `FileTree`, even though that is still possible.
- The `Runtime` now also has a `cli` method (if the `cli` feature is enabled).
- `Runtime` is now usually passed by reference.
- The fields of `Runtime` are now private. They never should have been public as incorrect usage can lead to unsafe behaviour.
- Removed the `type_registry` and `string_init_function` fields from the runtime because we should be using the global type registry and we can refer to the init function directly.
- Some docs of the `runtime` module have been moved to `Runtime` since the module is not public but the `Runtime` is.
- We guarantee that there is only one (global) `TypeRegistry` and remove it as an argument to a bunch of functions.
- Add a method `Runtime::add_io_functions` to add a simple `print` method so we can write a hello world program. I should expand on the idea of a basic runtime with some optional modules later.
- Moved printing of the docs from `src/runtime/mod.rs` to `src/runtime/docs.rs`. 