### PR TITLE
Add negation operator

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -143,6 +143,8 @@ pub enum Expr {
     /// Takes a left operand, the operator and the right operand
     BinOp(Box<Meta<Expr>>, BinOp, Box<Meta<Expr>>),
 
+    Negate(Box<Meta<Expr>>),
+
     /// An if or if-else expression
     IfElse(Box<Meta<Expr>>, Meta<Block>, Option<Meta<Block>>),
 }

--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -110,7 +110,7 @@ fn check_roto_type(
 
     let mut roto_ty = type_info.resolve(roto_ty);
 
-    if let Type::IntVar(_) = roto_ty {
+    if let Type::IntVar(_, _) = roto_ty {
         roto_ty = Type::named("i32", Vec::new());
     }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -771,6 +771,18 @@ impl<'c> FuncGen<'c> {
                 let val = self.ins().icmp_imm(IntCC::Equal, val, 0);
                 self.def(var, val);
             }
+            lir::Instruction::Negate { to, val } => {
+                let (val, val_ty) = self.operand(val);
+                let var = self.variable(to, val_ty);
+
+                let val = if let F32 | F64 = val_ty {
+                    self.ins().fneg(val)
+                } else {
+                    self.ins().ineg(val)
+                };
+
+                self.def(var, val)
+            }
             lir::Instruction::Add { to, left, right } => {
                 let (l, left_ty) = self.operand(left);
                 let (r, _) = self.operand(right);

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -187,7 +187,43 @@ fn equal_to_10_with_two_functions() {
 }
 
 #[test]
+fn negated_literal() {
+    let s = src!(
+        "
+        fn negate() -> i32 {
+            -5
+        }
+        "
+    );
+
+    let mut p = compile(s);
+    let f = p
+        .get_function::<(), fn() -> i32>("negate")
+        .expect("No function found (or mismatched types)");
+    let res = f.call(&mut ());
+    assert_eq!(res, -5)
+}
+
+#[test]
 fn negation() {
+    let s = src!(
+        "
+        fn negate(x: i32) -> i32 {
+            -x
+        }
+        "
+    );
+
+    let mut p = compile(s);
+    let f = p
+        .get_function::<(), fn(i32) -> i32>("negate")
+        .expect("No function found (or mismatched types)");
+    let res = f.call(&mut (), 5);
+    assert_eq!(res, -5)
+}
+
+#[test]
+fn inversion() {
     let s = src!(
         "
         filtermap main(x: i32) {

--- a/src/lir/eval.rs
+++ b/src/lir/eval.rs
@@ -483,6 +483,19 @@ pub fn eval(
                 let val = eval_operand(&vars, val).as_bool();
                 vars.insert(to.clone(), IrValue::Bool(val));
             }
+            Instruction::Negate { to, val } => {
+                let val = eval_operand(&vars, val);
+                let res = match val {
+                    IrValue::I8(x) => IrValue::I8(-x),
+                    IrValue::I16(x) => IrValue::I16(-x),
+                    IrValue::I32(x) => IrValue::I32(-x),
+                    IrValue::I64(x) => IrValue::I64(-x),
+                    IrValue::F32(x) => IrValue::F32(-x),
+                    IrValue::F64(x) => IrValue::F64(-x),
+                    _ => panic!(),
+                };
+                vars.insert(to.clone(), res);
+            }
             Instruction::Add { to, left, right } => {
                 let left = eval_operand(&vars, left);
                 let right = eval_operand(&vars, right);

--- a/src/lir/lower/clone_drop.rs
+++ b/src/lir/lower/clone_drop.rs
@@ -84,7 +84,7 @@ impl Lowerer<'_, '_> {
                     _ => return,
                 }
             }
-            Type::IntVar(_) => Primitive::i32().layout().size(),
+            Type::IntVar(_, _) => Primitive::i32().layout().size(),
             Type::FloatVar(_) => Primitive::f64().layout().size(),
         };
 
@@ -252,7 +252,7 @@ impl Lowerer<'_, '_> {
                     }
                 }
             }
-            Type::Never | Type::IntVar(_) | Type::FloatVar(_) => {}
+            Type::Never | Type::IntVar(_, _) | Type::FloatVar(_) => {}
             Type::Var(_) | Type::Function(_, _) | Type::ExplicitVar(_) => {
                 panic!("Can't traverse: {ty:?}")
             }

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -170,6 +170,9 @@ pub enum Instruction {
     /// Boolean not
     Not { to: Var, val: Operand },
 
+    /// Numeric negation
+    Negate { to: Var, val: Operand },
+
     /// Add offset to a pointer
     Offset { to: Var, from: Operand, offset: u32 },
 

--- a/src/lir/print.rs
+++ b/src/lir/print.rs
@@ -221,6 +221,13 @@ impl Printable for Instruction {
             Not { to, val } => {
                 format!("{} = not({})", to.print(printer), val.print(printer))
             }
+            Negate { to, val } => {
+                format!(
+                    "{} = negate({})",
+                    to.print(printer),
+                    val.print(printer)
+                )
+            }
             Add { to, left, right } => {
                 format!(
                     "{} = {} + {}",

--- a/src/mir/lower.rs
+++ b/src/mir/lower.rs
@@ -375,6 +375,7 @@ impl<'r> Lowerer<'r> {
             }
             ast::Expr::List(_list) => todo!(),
             ast::Expr::Not(expr) => self.not(expr),
+            ast::Expr::Negate(expr) => self.negate(expr),
             ast::Expr::Assign(expr, field) => self.assign(expr, field),
             ast::Expr::BinOp(left, op, right) => self.binop(left, op, right),
             ast::Expr::IfElse(condition, then, r#else) => {
@@ -626,6 +627,13 @@ impl<'r> Lowerer<'r> {
         let val = self.expr(expr);
         let var = self.assign_to_var(val, Type::bool());
         Value::Not(var)
+    }
+
+    fn negate(&mut self, expr: &Meta<ast::Expr>) -> Value {
+        let ty = self.type_info.type_of(expr);
+        let val = self.expr(expr);
+        let var = self.assign_to_var(val, ty.clone());
+        Value::Negate(var, ty)
     }
 
     fn assign(

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -103,6 +103,7 @@ pub enum Value {
     Clone(Place),
     Discriminant(Var),
     Not(Var),
+    Negate(Var, Type),
     Move(Var),
     BinOp {
         left: Var,

--- a/src/mir/print.rs
+++ b/src/mir/print.rs
@@ -162,6 +162,11 @@ impl Printable for Value {
                 let var = var.print(printer);
                 format!("not({var})")
             }
+            Value::Negate(var, ty) => {
+                let var = var.print(printer);
+                let ty = ty.display(printer.type_info);
+                format!("negate({var}: {ty})")
+            }
             Value::Move(var) => {
                 let var = var.print(printer);
                 format!("move({var})")

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -372,6 +372,11 @@ impl Parser<'_, '_> {
             let expr = self.access(r)?;
             let span = span.merge(self.get_span(&expr));
             Ok(self.spans.add(span, Expr::Not(Box::new(expr))))
+        } else if self.peek_is(Token::Hyphen) {
+            let span = self.take(Token::Hyphen)?;
+            let expr = self.access(r)?;
+            let span = span.merge(self.get_span(&expr));
+            Ok(self.spans.add(span, Expr::Negate(Box::new(expr))))
         } else {
             self.access(r)
         }

--- a/src/typechecker/cycle.rs
+++ b/src/typechecker/cycle.rs
@@ -87,7 +87,7 @@ fn visit<'a>(
 ) -> Result<(), String> {
     match ty {
         Type::Var(_)
-        | Type::IntVar(_)
+        | Type::IntVar(_, _)
         | Type::FloatVar(_)
         | Type::RecordVar(_, _) => {
             Err("there should be no unresolved type variables left".into())

--- a/src/typechecker/info.rs
+++ b/src/typechecker/info.rs
@@ -140,7 +140,7 @@ impl TypeInfo {
     pub fn is_numeric_type(&mut self, ty: &Type) -> bool {
         let ty = self.resolve(ty);
         match ty {
-            Type::FloatVar(_) | Type::IntVar(_) => true,
+            Type::FloatVar(_) | Type::IntVar(_, _) => true,
             Type::Name(name) => {
                 let type_def = self.resolve_type_name(&name);
                 type_def.is_float() || type_def.is_int()
@@ -168,7 +168,7 @@ impl TypeInfo {
     pub fn get_int_type(&mut self, ty: &Type) -> Option<(IntKind, IntSize)> {
         let ty = self.resolve(ty);
         match ty {
-            Type::IntVar(_) => Some((IntKind::Signed, IntSize::I32)),
+            Type::IntVar(_, _) => Some((IntKind::Signed, IntSize::I32)),
             Type::Name(name) => {
                 let type_def = self.resolve_type_name(&name);
                 if let TypeDefinition::Primitive(Primitive::Int(kind, size)) =
@@ -299,7 +299,7 @@ impl TypeInfo {
                 panic!("Can't get the layout of a function type")
             }
             Type::Never => panic!("Can't get the layout of the never type"),
-            Type::IntVar(_) => Primitive::i32().layout(),
+            Type::IntVar(_, _) => Primitive::i32().layout(),
             Type::FloatVar(_) => Primitive::f64().layout(),
             Type::RecordVar(_, fields) | Type::Record(fields) => {
                 Layout::concat(
@@ -354,7 +354,7 @@ impl TypeInfo {
     }
 
     pub fn resolve_ref<'a>(&'a self, mut t: &'a Type) -> &'a Type {
-        if let Type::Var(x) | Type::IntVar(x) | Type::RecordVar(x, _) = t {
+        if let Type::Var(x) | Type::IntVar(x, _) | Type::RecordVar(x, _) = t {
             t = self.unionfind.find_ref(*x);
         }
 
@@ -364,7 +364,7 @@ impl TypeInfo {
     pub fn resolve(&mut self, t: &Type) -> Type {
         let mut t = t.clone();
 
-        if let Type::Var(x) | Type::IntVar(x) | Type::RecordVar(x, _) = t {
+        if let Type::Var(x) | Type::IntVar(x, _) | Type::RecordVar(x, _) = t {
             t = self.unionfind.find(x).clone();
         }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -109,7 +109,9 @@ use scope::{
 };
 use scoped_display::TypeDisplay;
 use std::{any::TypeId, borrow::Borrow, collections::HashMap};
-use types::{FunctionDefinition, Type, TypeDefinition, TypeName};
+use types::{
+    FunctionDefinition, MustBeSigned, Type, TypeDefinition, TypeName,
+};
 
 use self::{
     error::TypeError,
@@ -708,7 +710,9 @@ impl TypeChecker {
 
     /// Create a fresh integer variable in the unionfind structure
     fn fresh_int(&mut self) -> Type {
-        self.type_info.unionfind.fresh(Type::IntVar)
+        self.type_info
+            .unionfind
+            .fresh(|n| Type::IntVar(n, types::MustBeSigned::No))
     }
 
     /// Create a fresh integer variable in the unionfind structure
@@ -949,16 +953,37 @@ impl TypeChecker {
             }
             // The never type is special and unifies with anything
             (Never, x) | (x, Never) => x,
-            (IntVar(a), b @ IntVar(_)) => {
+            (
+                IntVar(a, MustBeSigned::No),
+                b @ IntVar(_, MustBeSigned::Yes),
+            ) => {
                 self.type_info.unionfind.set(a, b.clone());
                 b.clone()
             }
-            (IntVar(b), Name(name)) | (Name(name), IntVar(b)) => {
+            (
+                a @ IntVar(_, MustBeSigned::Yes),
+                IntVar(b, MustBeSigned::No),
+            ) => {
+                self.type_info.unionfind.set(b, a.clone());
+                a.clone()
+            }
+            (IntVar(a, _), b @ IntVar(_, _)) => {
+                self.type_info.unionfind.set(a, b.clone());
+                b.clone()
+            }
+            (IntVar(b, s), Name(name)) | (Name(name), IntVar(b, s)) => {
                 if !name.arguments.is_empty() {
                     return None;
                 }
                 let type_def = self.type_info.resolve_type_name(&name);
-                if !type_def.is_int() {
+
+                let correct = if s == MustBeSigned::Yes {
+                    type_def.is_signed_int()
+                } else {
+                    type_def.is_int()
+                };
+
+                if !correct {
                     return None;
                 }
                 self.type_info.unionfind.set(b, Name(name.clone()));
@@ -1063,7 +1088,7 @@ impl TypeChecker {
     /// Resolve a type variable to a type.
     fn resolve_type(&mut self, t: &Type) -> Type {
         if let Type::Var(x)
-        | Type::IntVar(x)
+        | Type::IntVar(x, _)
         | Type::FloatVar(x)
         | Type::RecordVar(x, _) = t
         {

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -153,6 +153,59 @@ fn record_diamond() {
 }
 
 #[test]
+fn negation_on_unsigned_int_literal() {
+    let s = src!(
+        "
+        fn negate() -> u32 {
+            -5
+        }
+        "
+    );
+
+    assert!(typecheck(s).is_err());
+}
+
+#[test]
+fn negation_unify_with_unsigned() {
+    let s = src!(
+        "
+        fn negate(x: u32) -> u32 {
+            let y = -5;
+            x + y
+        }
+        "
+    );
+
+    assert!(typecheck(s).is_err());
+}
+
+#[test]
+fn negation_on_unsigned_int() {
+    let s = src!(
+        "
+        fn negate(x: u32) -> u32 {
+            -x
+        }
+        "
+    );
+
+    assert!(typecheck(s).is_err());
+}
+
+#[test]
+fn negation_on_string() {
+    let s = src!(
+        "
+        fn negate(x: String) -> String {
+            -x
+        }
+        "
+    );
+
+    assert!(typecheck(s).is_err());
+}
+
+#[test]
 #[ignore = "prefixes not supported yet"]
 fn filter_map() {
     let s = src!(

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -87,7 +87,13 @@ pub enum Type {
     Name(TypeName),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// Whether an integer type must be signed
+///
+/// We have to track this because the unary minus operator only allows signed
+/// integers. So, if we find a unary minus with an `IntVar` as argument, we
+/// set `MustBySigned` to `Yes`. If `MustBeSigned` is set to `Yes`, it will
+/// only unify with signed integer types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum MustBeSigned {
     Yes,
     No,

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -78,13 +78,19 @@ impl Type {
 pub enum Type {
     Var(usize),
     ExplicitVar(Identifier),
-    IntVar(usize),
+    IntVar(usize, MustBeSigned),
     FloatVar(usize),
     RecordVar(usize, Vec<(Meta<Identifier>, Type)>),
     Never,
     Record(Vec<(Meta<Identifier>, Type)>),
     Function(Vec<Type>, Box<Type>),
     Name(TypeName),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MustBeSigned {
+    Yes,
+    No,
 }
 
 /// A definition of a named type
@@ -310,7 +316,10 @@ impl TypeDisplay for Type {
         match ty {
             Type::Var(_) => write!(f, "_"),
             Type::ExplicitVar(s) => write!(f, "{s}"),
-            Type::IntVar(_) => write!(f, "{{integer}}"),
+            Type::IntVar(_, MustBeSigned::Yes) => {
+                write!(f, "{{signed integer}}")
+            }
+            Type::IntVar(_, MustBeSigned::No) => write!(f, "{{integer}}"),
             Type::FloatVar(_) => write!(f, "{{float}}"),
             Type::RecordVar(_, fields) | Type::Record(fields) => {
                 write!(
@@ -404,6 +413,10 @@ impl TypeDisplay for TypeName {
 }
 
 impl TypeDefinition {
+    pub fn is_signed_int(&self) -> bool {
+        matches!(self, Self::Primitive(Primitive::Int(IntKind::Signed, _)))
+    }
+
     pub fn is_int(&self) -> bool {
         matches!(self, Self::Primitive(Primitive::Int(_, _)))
     }

--- a/src/typechecker/unionfind.rs
+++ b/src/typechecker/unionfind.rs
@@ -22,7 +22,7 @@ impl UnionFind {
     pub fn find(&mut self, index: usize) -> Type {
         match &self.inner[index] {
             Type::Var(i)
-            | Type::IntVar(i)
+            | Type::IntVar(i, _)
             | Type::FloatVar(i)
             | Type::RecordVar(i, _)
                 if *i != index =>
@@ -51,7 +51,7 @@ impl UnionFind {
     pub fn find_ref(&self, index: usize) -> &Type {
         match &self.inner[index] {
             Type::Var(i)
-            | Type::IntVar(i)
+            | Type::IntVar(i, _)
             | Type::FloatVar(i)
             | Type::RecordVar(i, _)
                 if *i != index =>


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/181.

There's a particularly hairy type inference case:
```roto
fn foo(x: u32) {
   let y = -5;
   x + y;
}
```
The literal is negated and therefore the integer type must be signed, but we later unify it with `u32` so we have to give an error. I've done this by attaching some data to `IntVar`. The error message can be improved in the future, but for now this seems to work.