### PR TITLE
Improve path resolution error messages

### DIFF
--- a/src/typechecker/error.rs
+++ b/src/typechecker/error.rs
@@ -135,21 +135,6 @@ impl TypeChecker {
         }
     }
 
-    pub fn error_expected_enum(
-        &self,
-        ident: &Meta<Identifier>,
-        ty: &impl TypeDisplay,
-    ) -> TypeError {
-        TypeError {
-            description: format!(
-                "expected enum, but found type `{}`",
-                ty.display(&self.type_info)
-            ),
-            location: ident.id,
-            labels: vec![Label::error("expected type", ident.id)],
-        }
-    }
-
     pub fn error_expected_type(
         &self,
         ident: &Meta<Identifier>,
@@ -459,15 +444,75 @@ impl TypeChecker {
     pub fn error_no_field_on_type(
         &self,
         ty: &impl TypeDisplay,
-        field: &Meta<Identifier>,
+        ident: &Meta<Identifier>,
     ) -> TypeError {
         self.error_simple(
             format!(
-                "no field `{field}` on type `{}`",
+                "no field `{ident}` on type `{}`",
                 ty.display(&self.type_info)
             ),
-            format!("unknown field `{field}`"),
-            field.id,
+            format!("unknown field `{ident}`"),
+            ident.id,
+        )
+    }
+
+    pub fn error_no_method_on_type(
+        &self,
+        ty: &impl TypeDisplay,
+        ident: &Meta<Identifier>,
+    ) -> TypeError {
+        self.error_simple(
+            format!(
+                "no method `{ident}` on type `{}`",
+                ty.display(&self.type_info)
+            ),
+            format!("unknown method `{ident}`"),
+            ident.id,
+        )
+    }
+
+    pub fn error_no_static_method_on_type(
+        &self,
+        ty: &impl TypeDisplay,
+        ident: &Meta<Identifier>,
+    ) -> TypeError {
+        self.error_simple(
+            format!(
+                "no static method `{ident}` on type `{}`",
+                ty.display(&self.type_info)
+            ),
+            format!("unknown static method `{ident}`"),
+            ident.id,
+        )
+    }
+
+    pub fn error_no_variant_on_type(
+        &self,
+        ty: &impl TypeDisplay,
+        ident: &Meta<Identifier>,
+    ) -> TypeError {
+        self.error_simple(
+            format!(
+                "no variant or static method `{ident}` on type `{}`",
+                ty.display(&self.type_info)
+            ),
+            format!("unknown variant or static method `{ident}`"),
+            ident.id,
+        )
+    }
+
+    pub fn error_no_field_or_method_on_type(
+        &self,
+        ty: &impl TypeDisplay,
+        ident: &Meta<Identifier>,
+    ) -> TypeError {
+        self.error_simple(
+            format!(
+                "no field or method `{ident}` on type `{}`",
+                ty.display(&self.type_info)
+            ),
+            format!("unknown field or method `{ident}`"),
+            ident.id,
         )
     }
 

--- a/tests/scripts/type_errors/no_such_method.roto
+++ b/tests/scripts/type_errors/no_such_method.roto
@@ -1,0 +1,3 @@
+fn main() {
+	true.foofoo();
+}

--- a/tests/snapshots/snapshot__type_errors@field_does_not_exist.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@field_does_not_exist.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/field_does_not_exist.roto
 ---
-Error: Type error: no field `b` on type `pkg.Foo`
+Error: Type error: no field or method `b` on type `pkg.Foo`
    ╭─[ tests/scripts/type_errors/field_does_not_exist.roto:5:17 ]
    │
  5 │     let a = foo.b;
    │                 ┬  
-   │                 ╰── unknown field `b`
+   │                 ╰── unknown field or method `b`
 ───╯

--- a/tests/snapshots/snapshot__type_errors@invalid_field_access.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@invalid_field_access.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/invalid_field_access.roto
 ---
-Error: Type error: expected enum, but found type `String`
-   ╭─[ tests/scripts/type_errors/invalid_field_access.roto:2:10 ]
+Error: Type error: no static method `foo` on type `String`
+   ╭─[ tests/scripts/type_errors/invalid_field_access.roto:2:17 ]
    │
  2 │     let b = String.foo;
-   │             ───┬──  
-   │                ╰──── expected type
+   │                    ─┬─  
+   │                     ╰─── unknown static method `foo`
 ───╯

--- a/tests/snapshots/snapshot__type_errors@method_does_not_exist.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@method_does_not_exist.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/method_does_not_exist.roto
 ---
-Error: Type error: no field `foo` on type `u32`
+Error: Type error: no field or method `foo` on type `u32`
    ╭─[ tests/scripts/type_errors/method_does_not_exist.roto:2:6 ]
    │
  2 │     msg.foo();
    │         ─┬─  
-   │          ╰─── unknown field `foo`
+   │          ╰─── unknown field or method `foo`
 ───╯

--- a/tests/snapshots/snapshot__type_errors@no_such_method.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@no_such_method.roto.snap
@@ -1,0 +1,12 @@
+---
+source: tests/snapshot.rs
+expression: string
+input_file: tests/scripts/type_errors/no_such_method.roto
+---
+Error: Type error: no method `foofoo` on type `bool`
+   ╭─[ tests/scripts/type_errors/no_such_method.roto:2:7 ]
+   │
+ 2 │     true.foofoo();
+   │          ───┬──  
+   │             ╰──── unknown method `foofoo`
+───╯

--- a/tests/snapshots/snapshot__type_errors@no_such_static_method.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@no_such_static_method.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/no_such_static_method.roto
 ---
-Error: Type error: expected enum, but found type `String`
-   ╭─[ tests/scripts/type_errors/no_such_static_method.roto:2:5 ]
+Error: Type error: no static method `bar` on type `String`
+   ╭─[ tests/scripts/type_errors/no_such_static_method.roto:2:12 ]
    │
  2 │     String.bar();
-   │     ───┬──  
-   │        ╰──── expected type
+   │            ─┬─  
+   │             ╰─── unknown static method `bar`
 ───╯


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/166
Closes https://github.com/NLnetLabs/roto/issues/167

Biggest improvement is #166:
```
Error: Type error: no static method `bar` on type `String`
   ╭─[ tests/scripts/type_errors/no_such_static_method.roto:2:12 ]
   │
 2 │     String.bar();
   │            ─┬─  
   │             ╰─── unknown static method `bar`
───╯
```

but #167 is improved too:
```
Error: Type error: no field or method `foo` on type `u32`
   ╭─[ tests/scripts/type_errors/method_does_not_exist.roto:2:6 ]
   │
 2 │     msg.foo();
   │         ─┬─  
   │          ╰─── unknown field or method `foo`
───╯
```

Sometimes we can even make a message saying that it has to be a method (if the receiver is not a path):
```
Error: Type error: no method `foofoo` on type `bool`
   ╭─[ tests/scripts/type_errors/no_such_method.roto:2:7 ]
   │
 2 │     true.foofoo();
   │          ───┬──  
   │             ╰──── unknown method `foofoo`
───╯
```