### PR TITLE
Scopes of types

### DIFF
--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1736,8 +1736,6 @@ fn construct_optional_value() {
 }
 
 #[test]
-<<<<<<< Conflict 1 of 1
-+++++++ Contents of side #1
 fn construct_imported_optional() {
     let s = src!(
         "

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1736,11 +1736,39 @@ fn construct_optional_value() {
 }
 
 #[test]
+<<<<<<< Conflict 1 of 1
++++++++ Contents of side #1
 fn construct_imported_optional() {
     let s = src!(
         "
         import Optional.{Some, None};
 
+        fn sub_one(x: u32) -> u32? {
+            if x == 0 {
+                None
+            } else {
+                Some(x - 1)
+            }
+        }
+        "
+    );
+
+    let mut p = compile(s);
+
+    let f = p
+        .get_function::<(), fn(u32) -> Option<u32>>("sub_one")
+        .unwrap();
+
+    let res = f.call(&mut (), 0);
+    assert_eq!(res, None);
+    let res = f.call(&mut (), 2);
+    assert_eq!(res, Some(1));
+}
+
+#[test]
+fn construct_optional_value_from_prelude() {
+    let s = src!(
+        "
         fn sub_one(x: u32) -> u32? {
             if x == 0 {
                 None

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1447,6 +1447,48 @@ fn string_append() {
 }
 
 #[test]
+fn string_append_as_function_call() {
+    let s = src!(
+        r#"
+        fn main(name: String) -> String {
+            String.append("Hello ", name)
+        }
+    "#
+    );
+
+    let mut p = compile(s);
+
+    let f = p
+        .get_function::<(), fn(Arc<str>) -> Arc<str>>("main")
+        .unwrap();
+
+    let res = f.call(&mut (), "Martin".into());
+    assert_eq!(res, "Hello Martin".into());
+}
+
+#[test]
+fn string_append_as_imported_function() {
+    let s = src!(
+        r#"
+        import String.append;
+
+        fn main(name: String) -> String {
+            append("Hello ", name)
+        }
+    "#
+    );
+
+    let mut p = compile(s);
+
+    let f = p
+        .get_function::<(), fn(Arc<str>) -> Arc<str>>("main")
+        .unwrap();
+
+    let res = f.call(&mut (), "Martin".into());
+    assert_eq!(res, "Hello Martin".into());
+}
+
+#[test]
 fn string_plus_operator() {
     let s = src!(
         r#"
@@ -1676,6 +1718,34 @@ fn construct_optional_value() {
                 Optional.None
             } else {
                 Optional.Some(x - 1)
+            }
+        }
+        "
+    );
+
+    let mut p = compile(s);
+
+    let f = p
+        .get_function::<(), fn(u32) -> Option<u32>>("sub_one")
+        .unwrap();
+
+    let res = f.call(&mut (), 0);
+    assert_eq!(res, None);
+    let res = f.call(&mut (), 2);
+    assert_eq!(res, Some(1));
+}
+
+#[test]
+fn construct_imported_optional() {
+    let s = src!(
+        "
+        import Optional.{Some, None};
+
+        fn sub_one(x: u32) -> u32? {
+            if x == 0 {
+                None
+            } else {
+                Some(x - 1)
             }
         }
         "

--- a/src/mir/lower.rs
+++ b/src/mir/lower.rs
@@ -205,11 +205,12 @@ impl<'r> Lowerer<'r> {
         let name = self.type_info.resolved_name(&function.ident);
         let dec = self.type_info.scope_graph.get_declaration(name);
 
-        let DeclarationKind::Function(_, ty) = dec.kind else {
+        let DeclarationKind::Function(Some(func_dec)) = dec.kind else {
             ice!();
         };
 
-        let Type::Function(_, ret) = self.type_info.resolve(&ty) else {
+        let Type::Function(_, ret) = self.type_info.resolve(&func_dec.ty)
+        else {
             ice!("A function must have a function type");
         };
 

--- a/src/typechecker/error.rs
+++ b/src/typechecker/error.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    scope::{StubDeclaration, StubDeclarationKind},
+    scope::{DeclarationKind, ValueKind},
     scoped_display::TypeDisplay,
     types::Type,
     ResolvedPath, TypeChecker,
@@ -138,7 +138,7 @@ impl TypeChecker {
     pub fn error_expected_type(
         &self,
         ident: &Meta<Identifier>,
-        stub: StubDeclaration,
+        stub: Declaration,
     ) -> TypeError {
         let kind = describe_declaration(&stub);
         TypeError {
@@ -151,9 +151,9 @@ impl TypeChecker {
     pub fn error_expected_module(
         &self,
         ident: &Meta<Identifier>,
-        stub: StubDeclaration,
+        declaration: Declaration,
     ) -> TypeError {
-        let kind = describe_declaration(&stub);
+        let kind = describe_declaration(&declaration);
         TypeError {
             description: format!(
                 "expected a module, but found {kind} `{ident}`",
@@ -375,8 +375,7 @@ impl TypeChecker {
         ident: &Meta<Identifier>,
         declaration: &Declaration,
     ) -> TypeError {
-        let stub = declaration.to_stub();
-        let kind = describe_declaration(&stub);
+        let kind = describe_declaration(&declaration);
         TypeError {
             description: format!(
                 "expected a value, but found {kind} `{}`",
@@ -487,16 +486,16 @@ impl TypeChecker {
     }
 }
 
-fn describe_declaration(d: &StubDeclaration) -> &str {
+fn describe_declaration(d: &Declaration) -> &str {
     match &d.kind {
-        StubDeclarationKind::Context => "context",
-        StubDeclarationKind::Constant => "constant",
-        StubDeclarationKind::Variable => "variable",
-        StubDeclarationKind::Type(_) => "type",
-        StubDeclarationKind::Function => "function",
-        StubDeclarationKind::Module => "module",
-        StubDeclarationKind::Method => "method",
-        StubDeclarationKind::Variant => "variant",
+        DeclarationKind::Value(ValueKind::Local, _) => "variable",
+        DeclarationKind::Value(ValueKind::Constant, _) => "constant",
+        DeclarationKind::Value(ValueKind::Context(..), _) => "context",
+        DeclarationKind::Type(..) => "type",
+        DeclarationKind::Function(..) => "function",
+        DeclarationKind::Module => "module",
+        DeclarationKind::Method(..) => "method",
+        DeclarationKind::Variant(..) => "variant",
     }
 }
 

--- a/src/typechecker/error.rs
+++ b/src/typechecker/error.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    scope::{ResolvedName, StubDeclaration, StubDeclarationKind},
+    scope::{StubDeclaration, StubDeclarationKind},
     scoped_display::TypeDisplay,
     types::Type,
     ResolvedPath, TypeChecker,
@@ -407,7 +407,7 @@ impl TypeChecker {
                 ty.display(&self.type_info),
             ),
             location: expr.id,
-            labels: vec![Label::error("not a numberic value", expr.id)],
+            labels: vec![Label::error("not a numeric value", expr.id)],
         }
     }
 
@@ -471,36 +471,6 @@ impl TypeChecker {
         )
     }
 
-    pub fn error_no_static_method_on_type(
-        &self,
-        ty: &impl TypeDisplay,
-        ident: &Meta<Identifier>,
-    ) -> TypeError {
-        self.error_simple(
-            format!(
-                "no static method `{ident}` on type `{}`",
-                ty.display(&self.type_info)
-            ),
-            format!("unknown static method `{ident}`"),
-            ident.id,
-        )
-    }
-
-    pub fn error_no_variant_on_type(
-        &self,
-        ty: &impl TypeDisplay,
-        ident: &Meta<Identifier>,
-    ) -> TypeError {
-        self.error_simple(
-            format!(
-                "no variant or static method `{ident}` on type `{}`",
-                ty.display(&self.type_info)
-            ),
-            format!("unknown variant or static method `{ident}`"),
-            ident.id,
-        )
-    }
-
     pub fn error_no_field_or_method_on_type(
         &self,
         ty: &impl TypeDisplay,
@@ -515,23 +485,6 @@ impl TypeChecker {
             ident.id,
         )
     }
-
-    pub fn error_multiple_methods(
-        &self,
-        ident: &Meta<Identifier>,
-        candidates: &[ResolvedName],
-    ) -> TypeError {
-        self.error_simple(
-            format!(
-                "multiple possible methods for {ident}: {}",
-                join_quoted(
-                    candidates.iter().map(|c| c.display(&self.type_info))
-                )
-            ),
-            "multiple possible methods".to_string(),
-            ident.id,
-        )
-    }
 }
 
 fn describe_declaration(d: &StubDeclaration) -> &str {
@@ -542,6 +495,8 @@ fn describe_declaration(d: &StubDeclaration) -> &str {
         StubDeclarationKind::Type(_) => "type",
         StubDeclarationKind::Function => "function",
         StubDeclarationKind::Module => "module",
+        StubDeclarationKind::Method => "method",
+        StubDeclarationKind::Variant => "variant",
     }
 }
 

--- a/src/typechecker/expr.rs
+++ b/src/typechecker/expr.rs
@@ -1220,6 +1220,9 @@ impl TypeChecker {
                     variant: variant.clone(),
                 })
             }
+            DeclarationKind::Stub(_) => {
+                ice!()
+            }
         }
     }
 

--- a/src/typechecker/info.rs
+++ b/src/typechecker/info.rs
@@ -16,7 +16,9 @@ use crate::{
 
 use super::{
     expr::ResolvedPath,
-    scope::{DeclarationKind, ResolvedName, ScopeGraph, ScopeRef},
+    scope::{
+        DeclarationKind, ResolvedName, ScopeGraph, ScopeRef, TypeOrStub,
+    },
     types::{
         Function, IntKind, IntSize, Primitive, Signature, Type,
         TypeDefinition, TypeName,
@@ -238,8 +240,8 @@ impl TypeInfo {
     pub fn resolve_type_name(&mut self, ty: &TypeName) -> TypeDefinition {
         let name = ty.name;
         let dec = self.scope_graph.get_declaration(name);
-        let DeclarationKind::Type(ty) = dec.kind else {
-            panic!()
+        let DeclarationKind::Type(TypeOrStub::Type(ty)) = dec.kind else {
+            ice!()
         };
         ty
     }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -258,6 +258,35 @@ impl TypeChecker {
         self.declare_runtime_functions(runtime)?;
         self.declare_constants(runtime)?;
         self.declare_context(runtime)?;
+
+        // Little hack to put Some and None in the global namespace until
+        // imports can be specified from the runtime.
+        let stub = self
+            .type_info
+            .scope_graph
+            .resolve_name(
+                ScopeRef::GLOBAL,
+                &Meta {
+                    node: "Optional".into(),
+                    id: MetaId(0),
+                },
+                false,
+            )
+            .unwrap();
+        for variant in ["Some", "None"] {
+            self.type_info
+                .scope_graph
+                .insert_import(
+                    ScopeRef::GLOBAL,
+                    MetaId(0),
+                    ResolvedName {
+                        scope: stub.scope.unwrap(),
+                        ident: variant.into(),
+                    },
+                )
+                .unwrap();
+        }
+
         Ok(())
     }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -108,8 +108,8 @@ use crate::{
 };
 use cycle::detect_type_cycles;
 use scope::{
-    Declaration, DeclarationKind, ModuleScope, ResolvedName, ScopeRef,
-    ScopeType, StubDeclarationKind,
+    DeclarationKind, ModuleScope, ResolvedName, ScopeRef, ScopeType,
+    StubDeclarationKind,
 };
 use scoped_display::TypeDisplay;
 use std::{any::TypeId, borrow::Borrow};
@@ -231,20 +231,12 @@ impl TypeChecker {
                                 node: variant.name,
                                 id: MetaId(0),
                             },
-                            Declaration {
-                                name: ResolvedName {
-                                    ident: variant.name,
-                                    scope,
-                                },
-                                kind: DeclarationKind::Variant(
-                                    type_def.clone(),
-                                    variant.clone(),
-                                ),
-                                id: MetaId(0),
-                                scope: None,
-                            },
+                            DeclarationKind::Variant(
+                                type_def.clone(),
+                                variant.clone(),
+                            ),
                         )
-                        .unwrap()
+                        .unwrap();
                 }
             }
 

--- a/tests/snapshots/snapshot__type_errors@invalid_field_access.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@invalid_field_access.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/invalid_field_access.roto
 ---
-Error: Type error: no static method `foo` on type `String`
+Error: Type error: cannot find value `foo` in this scope
    ╭─[ tests/scripts/type_errors/invalid_field_access.roto:2:17 ]
    │
  2 │     let b = String.foo;
    │                    ─┬─  
-   │                     ╰─── unknown static method `foo`
+   │                     ╰─── not found in this scope
 ───╯

--- a/tests/snapshots/snapshot__type_errors@no_such_static_method.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@no_such_static_method.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/no_such_static_method.roto
 ---
-Error: Type error: no static method `bar` on type `String`
+Error: Type error: cannot find value `bar` in this scope
    ╭─[ tests/scripts/type_errors/no_such_static_method.roto:2:12 ]
    │
  2 │     String.bar();
    │            ─┬─  
-   │             ╰─── unknown static method `bar`
+   │             ╰─── not found in this scope
 ───╯


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/123.

This PR puts variants, methods and static methods into the scope graph. This has some observable side effects:

- Variants can now be imported (i.e. `import Optional.Some`)
- Static methods can now be imported (i.e. `import Prefix.new`)
- Methods can now be imported (i.e. `import String.append`)
- Methods can now be called as functions (i.e. `String.append(x,y)` instead of `x.append(y)`)

Additionally, `Optional.Some` and `Optional.None` are now added to the root scope via an import, so `Some` and `None` can be used directly without any imports.

Keeping as a draft while I ponder whether I should refactor the `Declaration/StubDeclaration` thing. It's getting harder to keep them in sync.