### PR TITLE
Redo constants implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
+    - name: Run apt-get update
+      run: sudo apt-get update
     - name: Install Valgrind
       run: sudo apt-get install -y valgrind
     - name: Install Just

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -2849,3 +2849,22 @@ fn return_verdict_from_runtime_function() {
 
     assert_eq!(Verdict::Accept(()), func.call(&mut ()));
 }
+
+#[test]
+fn string_global() {
+    let s = src!(
+        "fn use_foo() -> String {
+            FOO
+        }"
+    );
+
+    let mut runtime = Runtime::new();
+
+    let foo: Arc<str> = "BAR".into();
+    runtime.register_constant("FOO", "...", foo).unwrap();
+
+    let mut p = compile_with_runtime(s, runtime);
+    let f = p.get_function::<(), fn() -> Arc<str>>("use_foo").unwrap();
+
+    assert_eq!(f.call(&mut ()), "BAR".into());
+}

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -82,12 +82,8 @@ pub enum Instruction {
     /// Assign the value `val` to `to`.
     Assign { to: Var, val: Operand, ty: IrType },
 
-    /// Load a constant
-    LoadConstant {
-        to: Var,
-        name: Identifier,
-        ty: IrType,
-    },
+    /// Get the address of a constant
+    ConstantAddress { to: Var, name: Identifier },
 
     /// Create string
     InitString {

--- a/src/lir/print.rs
+++ b/src/lir/print.rs
@@ -116,9 +116,9 @@ impl Printable for Instruction {
                     val.print(printer),
                 )
             }
-            LoadConstant { to, name, ty } => {
+            ConstantAddress { to, name } => {
                 format!(
-                    "{}: {ty} = LoadConstant(\"{}\")",
+                    "{} = ConstantAddress(\"{}\")",
                     to.print(printer),
                     name
                 )
@@ -183,7 +183,10 @@ impl Printable for Instruction {
                 string,
                 init_func: _,
             } => {
-                format!("{}: String = \"{string}\"", to.print(printer),)
+                format!(
+                    "{}: String = InitString(\"{string}\")",
+                    to.print(printer),
+                )
             }
             Return(None) => "return".to_string(),
             Return(Some(v)) => {

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1,3 +1,5 @@
+use crate::Val;
+
 use super::Runtime;
 use roto_macros::{roto_function, roto_method, roto_static_method};
 use routecore::bgp::{
@@ -28,7 +30,7 @@ pub fn routecore_runtime() -> Result<Runtime, String> {
     rt.register_constant(
         "BLACKHOLE",
         "The well-known BLACKHOLE community.",
-        Community::from(Wellknown::Blackhole),
+        Val(Community::from(Wellknown::Blackhole)),
     )
     .unwrap();
 

--- a/src/runtime/ty.rs
+++ b/src/runtime/ty.rs
@@ -145,16 +145,6 @@ pub trait Reflect: Sized + 'static {
     ///
     /// The information is also returned for direct use.
     fn resolve() -> Ty;
-
-    /// Turn this value into bytes
-    ///
-    /// This is used by the IR evaluator
-    fn to_bytes(mut transformed: Self::Transformed) -> Vec<u8> {
-        let ptr = &mut transformed as *mut Self::Transformed as *mut u8;
-        std::mem::forget(transformed);
-        let size = std::mem::size_of::<Self::Transformed>();
-        unsafe { Vec::from_raw_parts(ptr, size, size) }
-    }
 }
 
 pub struct IrValueDoesNotMatchType;


### PR DESCRIPTION
Closes #203
Closes #204
Closes #205
Closes #206
Closes #207

## Description

The implementation of constants was lagging behind and highly unsound (see #203, #204, #205, #206, #207). This PR makes it so that we don't use cranelift's "global value" feature for constants, which was probably never the right choice because it's meant for static data, not constants as Roto understands them. Instead, we box each constant in Rust and store its address. In the compiled script, we then clone that value into the script. This matches what we basically already do for every other value and is much safer.

However, we access these values from possibly multiple threads at the same time, so they have to be `Send` and `Sync`. This isn't really an issue we had in Roto before; every value so far was local to a function. This poses some questions about whether we should have multiple versions of the runtime, depending on whether the user wants functions to be `Send` and `Sync` or not.

## Breaking changes as a result of this PR

- Constants now must implement `Reflect`.
- Constants must be `Send` and `Sync`.