### PR TITLE
Add `()` value and rename `Unit` to `()`

### DIFF
--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -74,7 +74,7 @@ fn check_roto_type(
     rust_ty: TypeId,
     roto_ty: &Type,
 ) -> Result<(), TypeMismatch> {
-    // Convert this to consts when TypeId::of is const on stable
+    // TODO: Convert this to consts when TypeId::of is const on stable
     let BOOL: TypeId = TypeId::of::<bool>();
     let U8: TypeId = TypeId::of::<u8>();
     let U16: TypeId = TypeId::of::<u16>();
@@ -116,6 +116,14 @@ fn check_roto_type(
 
     match rust_ty.description {
         TypeDescription::Leaf => {
+            if rust_ty.type_id == UNIT {
+                return if roto_ty == Type::Unit {
+                    Ok(())
+                } else {
+                    Err(error_message)
+                };
+            }
+
             let expected_name = match rust_ty.type_id {
                 x if x == BOOL => "bool",
                 x if x == U8 => "u8",
@@ -128,7 +136,6 @@ fn check_roto_type(
                 x if x == I64 => "i64",
                 x if x == F32 => "f32",
                 x if x == F64 => "f64",
-                x if x == UNIT => "Unit",
                 x if x == ASN => "Asn",
                 x if x == IPADDR => "IpAddr",
                 x if x == PREFIX => "Prefix",

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -39,6 +39,45 @@ fn compile_with_runtime(f: FileTree, runtime: Runtime) -> Compiled {
 }
 
 #[test]
+fn unit() {
+    let s = src!(
+        "
+        fn unit_expression() {
+            if true {
+                ()
+            } else {
+                ()
+            }
+        }
+    "
+    );
+    let mut p = compile(s);
+    let f = p
+        .get_function::<(), fn() -> ()>("unit_expression")
+        .expect("No function found (or mismatched types)");
+
+    let _res = f.call(&mut ());
+}
+
+#[test]
+fn unit_type() {
+    let s = src!(
+        "
+        fn unit_type() -> () {
+            let x: () = ();
+            x
+        }
+    "
+    );
+    let mut p = compile(s);
+    let f = p
+        .get_function::<(), fn() -> ()>("unit_type")
+        .expect("No function found (or mismatched types)");
+
+    let _res = f.call(&mut ());
+}
+
+#[test]
 fn accept() {
     let s = src!(
         "

--- a/src/lir/lower/clone_drop.rs
+++ b/src/lir/lower/clone_drop.rs
@@ -63,6 +63,7 @@ impl Lowerer<'_, '_> {
             }
             // These aren't copied, since they aren't leafs or zero sized
             Type::Never
+            | Type::Unit
             | Type::Record(_)
             | Type::RecordVar(_, _)
             | Type::Function(_, _) => return,
@@ -267,7 +268,10 @@ impl Lowerer<'_, '_> {
                     }
                 }
             }
-            Type::Never | Type::IntVar(_, _) | Type::FloatVar(_) => {}
+            Type::Never
+            | Type::Unit
+            | Type::IntVar(_, _)
+            | Type::FloatVar(_) => {}
             Type::Var(_) | Type::Function(_, _) | Type::ExplicitVar(_) => {
                 panic!("Can't traverse: {ty:?}")
             }

--- a/src/runtime/basic.rs
+++ b/src/runtime/basic.rs
@@ -99,13 +99,6 @@ impl Runtime {
             constants: Default::default(),
         };
 
-        rt.register_value_type_with_name::<()>(
-            "Unit",
-            "The unit type that has just one possible value. It can be used \
-            when there is nothing meaningful to be returned.",
-        )
-        .unwrap();
-
         rt.register_value_type::<bool>(
             "The boolean type\n\n\
             This type has two possible values: `true` and `false`. Several \

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -45,7 +45,6 @@ pub fn default_runtime() {
     assert_eq!(
         names,
         &[
-            "Unit",
             "bool",
             "u8",
             "u16",

--- a/src/typechecker/cycle.rs
+++ b/src/typechecker/cycle.rs
@@ -95,6 +95,7 @@ fn visit<'a>(
         Type::Never => {
             Err("never should not appear in a type declaration".into())
         }
+        Type::Unit => Ok(()),
         Type::Function(_, _) => Ok(()),
         Type::ExplicitVar(_) => Ok(()),
         Type::Record(fields) => {

--- a/src/typechecker/info.rs
+++ b/src/typechecker/info.rs
@@ -318,6 +318,7 @@ impl TypeInfo {
             Type::Function(_, _) => {
                 ice!("Can't get the layout of a function type")
             }
+            Type::Unit => Layout::new(0, 1),
             Type::Var(_) | Type::Never => return None,
             Type::IntVar(_, _) => Primitive::i32().layout(),
             Type::FloatVar(_) => Primitive::f64().layout(),

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -441,6 +441,11 @@ impl TypeChecker {
         t: TypeId,
     ) -> Result<Type, TypeError> {
         let ty = TypeRegistry::get(t).unwrap();
+
+        if ty.type_id == TypeId::of::<()>() {
+            return Ok(Type::Unit);
+        }
+
         match ty.description {
             TypeDescription::Leaf => {
                 let ident =

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -20,7 +20,7 @@ use super::{
 
 impl Type {
     pub fn unit() -> Type {
-        Type::named("Unit", Vec::new())
+        Type::Unit
     }
 
     pub fn bool() -> Type {
@@ -81,6 +81,7 @@ pub enum Type {
     IntVar(usize, MustBeSigned),
     FloatVar(usize),
     RecordVar(usize, Vec<(Meta<Identifier>, Type)>),
+    Unit,
     Never,
     Record(Vec<(Meta<Identifier>, Type)>),
     Function(Vec<Type>, Box<Type>),
@@ -119,7 +120,6 @@ pub struct EnumVariant {
 pub enum Primitive {
     Int(IntKind, IntSize),
     Float(FloatSize),
-    Unit,
     String,
     Bool,
     Asn,
@@ -288,7 +288,6 @@ impl Display for Primitive {
                 Primitive::Int(ty, size) =>
                     format!("{}{}", ty.prefix(), size.int()),
                 Primitive::Float(size) => format!("f{}", size.int()),
-                Primitive::Unit => "Unit".into(),
                 Primitive::String => "String".into(),
                 Primitive::Bool => "bool".into(),
                 Primitive::Asn => "Asn".into(),
@@ -340,6 +339,7 @@ impl TypeDisplay for Type {
                         .join(", ")
                 )
             }
+            Type::Unit => write!(f, "()"),
             Type::Never => write!(f, "!"),
             Type::Function(args, ret) => {
                 write!(
@@ -495,7 +495,6 @@ impl Primitive {
             }
             Bool => Layout::new(1, 1),
             Asn => Layout::new(4, 4),
-            Unit => Layout::new(0, 1),
             String => Layout::of::<Arc<str>>(),
             IpAddr => Layout::of::<std::net::IpAddr>(),
             Prefix => Layout::of::<inetnum::addr::Prefix>(),
@@ -571,7 +570,6 @@ pub fn default_types() -> Vec<(Identifier, TypeDefinition)> {
         ("f64", Float(FloatSize::F64)),
         ("bool", Bool),
         ("String", String),
-        ("Unit", Unit),
         ("Asn", Asn),
         ("IpAddr", IpAddr),
         ("Prefix", Prefix),

--- a/tests/snapshots/snapshot__type_errors@missing_accept_or_reject.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@missing_accept_or_reject.roto.snap
@@ -8,5 +8,5 @@ Error: Type error: mismatched types
    │
  2 │     if 2 == 4 { reject }
    │     ──────────┬─────────  
-   │               ╰─────────── expected `Verdict[_, _]`, found `Unit`
+   │               ╰─────────── expected `Verdict[_, _]`, found `()`
 ───╯

--- a/tests/snapshots/snapshot__type_errors@unreachable_expression.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@unreachable_expression.roto.snap
@@ -8,5 +8,5 @@ Error: Type error: mismatched types
    │
  2 │     return true;
    │            ──┬─  
-   │              ╰─── expected `Unit`, found `bool`
+   │              ╰─── expected `()`, found `bool`
 ───╯


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/218.