### PR TITLE
Clean up public API even more and more doc comments

### DIFF
--- a/docs/source/embedding/call_a_function.rst
+++ b/docs/source/embedding/call_a_function.rst
@@ -25,8 +25,8 @@ parameter ``4``.
 
         // Step 2: Compile the script and check for type errors
         let result = runtime.compile("script.roto");
-        let compiled = match result {
-            Ok(compiled) => compiled,
+        let pkg = match result {
+            Ok(pkg) => pkg,
             Err(err) => {
                 eprint!("{e}");
                 return 1;

--- a/docs/source/embedding/expand_the_runtime.rst
+++ b/docs/source/embedding/expand_the_runtime.rst
@@ -94,8 +94,8 @@ Not very useful yet, of course, but let's see it in action anyway:
 
     use roto::Val;
 
-    let compiled = runtime.read("script.roto").unwrap();
-    let f = compiled
+    let pkg = runtime.read("script.roto").unwrap();
+    let f = pkg
         .get_function::<_, fn(Val<Range>) -> Val<Range>>("passthrough")
         .unwrap();
 
@@ -130,8 +130,8 @@ expose methods on it to Roto.
         range.low <= x && x < range.high
     }
 
-    let compiled = runtime.read("script.roto").unwrap();
-    let f = compiled
+    let pkg = runtime.read("script.roto").unwrap();
+    let f = pkg
         .get_function::<_, fn(Val<Range>, x: i64) -> Val<Range>>("in_range")
         .unwrap();
 

--- a/examples/context.roto
+++ b/examples/context.roto
@@ -1,0 +1,3 @@
+fn greeting() -> String {
+    "Hello, " + first_name + " " + last_name + "!"
+}

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use roto::{Context, Runtime};
+
+#[derive(Context)]
+struct Ctx {
+    pub first_name: Arc<str>,
+    pub last_name: Arc<str>,
+}
+
+fn main() {
+    let mut runtime = Runtime::new();
+    runtime.register_context_type::<Ctx>().unwrap();
+
+    let mut pkg = runtime.compile("examples/context.roto").unwrap();
+
+    let f = pkg
+        .get_function::<Ctx, fn() -> Arc<str>>("greeting")
+        .unwrap();
+
+    let mut ctx = Ctx {
+        first_name: "John".into(),
+        last_name: "Doe".into(),
+    };
+    println!("{}", f.call(&mut ctx));
+}

--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -1,6 +1,7 @@
 use inetnum::{addr::Prefix, asn::Asn};
 
 use crate::{
+    lir::{IrValue, Memory},
     runtime::ty::{Reflect, TypeDescription, TypeRegistry},
     typechecker::{
         info::TypeInfo,
@@ -8,7 +9,6 @@ use crate::{
         scoped_display::TypeDisplay,
         types::{Type, TypeDefinition},
     },
-    IrValue, Memory,
 };
 use std::{
     any::TypeId, fmt::Display, mem::MaybeUninit, net::IpAddr, ops::Deref,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -15,13 +15,15 @@ use crate::{
     ast::Identifier,
     ice,
     label::{LabelRef, LabelStore},
-    lir::{self, value::IrType, FloatCmp, IntCmp, Operand, Var, VarKind},
+    lir::{
+        self, value::IrType, FloatCmp, IntCmp, IrValue, Operand, Var, VarKind,
+    },
     runtime::{
         context::ContextDescription, ty::Reflect, Constant, RuntimeConstant,
         RuntimeFunctionRef,
     },
     typechecker::{info::TypeInfo, scope::ScopeRef, types},
-    IrValue, Runtime,
+    Runtime,
 };
 use check::{
     check_roto_type_reflect, FunctionRetrievalError, RotoFunc, TypeMismatch,

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -8,19 +8,19 @@ use inetnum::{addr::Prefix, asn::Asn};
 use roto_macros::{roto_function, roto_method, roto_static_method};
 
 use crate::{
-    file_tree::FileSpec, pipeline::Compiled,
+    file_tree::FileSpec, pipeline::Package,
     runtime::tests::routecore_runtime, source_file, src, Context, FileTree,
     Runtime, Val, Verdict,
 };
 
 #[track_caller]
-fn compile(f: FileTree) -> Compiled {
+fn compile(f: FileTree) -> Package {
     let runtime = routecore_runtime().unwrap();
     compile_with_runtime(f, runtime)
 }
 
 #[track_caller]
-fn compile_with_runtime(f: FileTree, runtime: Runtime) -> Compiled {
+fn compile_with_runtime(f: FileTree, runtime: Runtime) -> Package {
     #[cfg(feature = "logger")]
     let _ = env_logger::try_init();
 

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::{Compiled, RotoReport, Runtime};
+use crate::{Package, RotoReport, Runtime};
 
 /// A filename with its contents
 #[derive(Clone, Debug)]
@@ -40,7 +40,7 @@ impl SourceFile {
     }
 }
 
-/// Compiler stage: Files loaded and ready to be parsed
+/// A set of files loaded and ready to be parsed
 pub struct FileTree {
     /// All files
     ///
@@ -49,10 +49,10 @@ pub struct FileTree {
 }
 
 impl FileTree {
-    pub fn compile(self, rt: &Runtime) -> Result<Compiled, RotoReport> {
+    pub fn compile(self, rt: &Runtime) -> Result<Package, RotoReport> {
         let checked = self.parse()?.typecheck(rt)?;
-        let compiled = checked.lower_to_mir().lower_to_lir().codegen();
-        Ok(compiled)
+        let pkg = checked.lower_to_mir().lower_to_lir().codegen();
+        Ok(pkg)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,23 +23,23 @@ mod typechecker;
 #[cfg(feature = "cli")]
 pub use cli::cli;
 
+#[cfg(test)]
+pub(crate) use pipeline::{source_file, src};
+
 pub use codegen::TypedFunc;
 pub use file_tree::{FileSpec, FileTree, SourceFile};
-pub use lir::eval::Memory;
-pub use lir::value::IrValue;
-pub use pipeline::{Compiled, LoweredToLir, RotoError, RotoReport};
+pub use pipeline::{Package, RotoError, RotoReport};
 pub use roto_macros::{
     roto_function, roto_method, roto_static_method, Context,
 };
 pub use runtime::{
-    context::{Context, ContextField},
-    func::Func,
-    option::RotoOption,
-    ty::Reflect,
-    val::Val,
-    verdict::Verdict,
-    Runtime, RuntimeType,
+    context::Context, ty::Reflect, val::Val, verdict::Verdict, Runtime,
 };
+
+/// Items exported only for use in macros
+pub mod __internal {
+    pub use crate::runtime::context::ContextField;
+}
 
 pub(crate) const FIND_HELP: &str = "\n\
     If you are seeing this error you have found a bug in the Roto compiler.\n\

--- a/src/lir/lower.rs
+++ b/src/lir/lower.rs
@@ -6,6 +6,7 @@ use crate::{
     ast::{self, Identifier, Literal},
     ice,
     label::{LabelRef, LabelStore},
+    lir::IrValue,
     mir,
     runtime::{
         init_string,
@@ -21,7 +22,7 @@ use crate::{
             TypeDefinition,
         },
     },
-    IrValue, Runtime,
+    Runtime,
 };
 
 use super::{

--- a/src/lir/mod.rs
+++ b/src/lir/mod.rs
@@ -28,17 +28,16 @@ pub mod value;
 #[cfg(test)]
 mod test_eval;
 
-pub use lower::lower_to_lir;
-use std::{fmt::Display, sync::Arc};
-
 use crate::{
     ast::Identifier,
     label::LabelRef,
     runtime::{self, layout::Layout},
     typechecker::{self, scope::ScopeRef},
 };
-
-use value::{IrType, IrValue};
+pub use eval::Memory;
+pub use lower::lower_to_lir;
+use std::{fmt::Display, sync::Arc};
+pub use value::{IrType, IrValue};
 
 /// Human-readable place
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/lir/test_eval.rs
+++ b/src/lir/test_eval.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use super::{eval::Memory, value::IrValue};
 use crate::{
-    runtime::tests::routecore_runtime, src, FileTree, LoweredToLir, Runtime,
+    pipeline::LoweredToLir, runtime::tests::routecore_runtime, src, FileTree,
+    Runtime,
 };
 
 #[track_caller]

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -4,7 +4,7 @@ use std::any::{type_name, TypeId};
 ///
 /// This declares a set of global variables that are initialized just before
 /// the script is run.
-pub trait Context: 'static {
+pub unsafe trait Context: 'static {
     /// Return the fields of this struct, their offsets and their types
     fn fields() -> Vec<ContextField>;
 
@@ -33,7 +33,7 @@ pub struct ContextField {
     pub docstring: String,
 }
 
-impl Context for () {
+unsafe impl Context for () {
     fn fields() -> Vec<ContextField> {
         Vec::new()
     }

--- a/src/runtime/docs.rs
+++ b/src/runtime/docs.rs
@@ -1,11 +1,8 @@
 use std::any::TypeId;
 
-use crate::{
-    runtime::{
-        context::ContextDescription, FunctionKind, RuntimeConstant,
-        RuntimeFunction,
-    },
-    Runtime, RuntimeType,
+use super::{
+    context::ContextDescription, FunctionKind, Runtime, RuntimeConstant,
+    RuntimeFunction, RuntimeType,
 };
 
 impl Runtime {
@@ -74,6 +71,9 @@ impl Runtime {
         println!();
     }
 
+    /// Print documentation for all the types registerd into this runtime.
+    ///
+    /// The format for the documentation is markdown that can be passed to Sphinx.
     pub fn print_documentation(&self) {
         println!("# Standard Library");
         println!();
@@ -91,7 +91,7 @@ impl Runtime {
             fields,
         }) = &self.context
         {
-            for crate::ContextField {
+            for super::context::ContextField {
                 name,
                 offset: _,
                 type_name: _,

--- a/src/runtime/func.rs
+++ b/src/runtime/func.rs
@@ -2,61 +2,6 @@ use std::any::TypeId;
 
 use crate::codegen::check::{RotoFunc, RustIrFunction};
 
-pub struct Func<F: RotoFunc> {
-    wrapper: <F as RotoFunc>::RustWrapper,
-    docstring: &'static str,
-    argument_names: &'static [&'static str],
-}
-
-impl<F: RotoFunc> Func<F> {
-    /// Construct a new [`Func`] to register to Roto.
-    ///
-    /// # Safety
-    ///
-    /// The `wrapper` argument must be a function that can be called safely
-    /// from Roto.
-    ///
-    /// Use the [`roto_function`], [`roto_method`] and [`roto_static_method`]
-    /// macros to be sure of that.
-    ///
-    /// [`roto_function`]: crate::roto_function
-    /// [`roto_method`]: crate::roto_method
-    /// [`roto_static_method`]: crate::roto_static_method
-    pub unsafe fn new(
-        wrapper: <F as RotoFunc>::RustWrapper,
-        docstring: &'static str,
-        argument_names: &'static [&'static str],
-    ) -> Self {
-        Self {
-            wrapper,
-            docstring,
-            argument_names,
-        }
-    }
-
-    pub(crate) fn docstring(&self) -> &'static str {
-        self.docstring
-    }
-
-    pub(crate) fn argument_names(&self) -> &'static [&'static str] {
-        self.argument_names
-    }
-
-    pub(crate) fn to_function_description(&self) -> FunctionDescription {
-        let parameter_types = F::parameter_types();
-        let return_type = F::return_type();
-        let pointer = F::ptr(&self.wrapper);
-        let ir_function = F::ir_function(&self.wrapper);
-
-        FunctionDescription {
-            parameter_types,
-            return_type,
-            pointer,
-            ir_function,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct FunctionDescription {
     parameter_types: Vec<TypeId>,
@@ -73,6 +18,20 @@ unsafe impl Send for FunctionDescription {}
 unsafe impl Sync for FunctionDescription {}
 
 impl FunctionDescription {
+    pub fn of<F: RotoFunc>(wrapper: F::RustWrapper) -> Self {
+        let parameter_types = F::parameter_types();
+        let return_type = F::return_type();
+        let pointer = F::ptr(&wrapper);
+        let ir_function = F::ir_function(&wrapper);
+
+        Self {
+            parameter_types,
+            return_type,
+            pointer,
+            ir_function,
+        }
+    }
+
     pub fn parameter_types(&self) -> &[TypeId] {
         &self.parameter_types
     }

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -5,6 +5,13 @@ use roto_macros::roto_function;
 use crate::Runtime;
 
 impl Runtime {
+    /// Add functions using I/O to the runtime.
+    ///
+    /// These functions are disabled by default because Roto might be used in a
+    /// context where using I/O is not permitted.
+    ///
+    /// For now, this just adds the `print` function. More functions will be
+    /// added in the future.
     pub fn add_io_functions(&mut self) {
         let rt = self;
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use context::ContextDescription;
-use func::{Func, FunctionDescription};
+use func::FunctionDescription;
 use layout::Layout;
 use ty::{Reflect, Ty, TypeDescription, TypeRegistry};
 
@@ -27,7 +27,7 @@ use crate::{
     ast::Identifier,
     codegen::check::RotoFunc,
     parser::token::{Lexer, Token},
-    Compiled, Context, FileTree, RotoReport,
+    Context, FileTree, Package, RotoReport,
 };
 
 /// Provides the types and functions that Roto can access via FFI
@@ -78,10 +78,14 @@ pub struct Runtime {
 }
 
 impl Runtime {
+    /// Compile a script from a path and return the result.
+    ///
+    /// If the path is a file, then that file will be loaded. If the path is a
+    /// directory, the directory will be scanned for modules.
     pub fn compile(
         &self,
         path: impl AsRef<Path>,
-    ) -> Result<Compiled, RotoReport> {
+    ) -> Result<Package, RotoReport> {
         FileTree::read(path).compile(self)
     }
 }
@@ -202,7 +206,7 @@ pub struct RuntimeFunction {
     /// Unique identifier for this function
     pub(crate) id: usize,
 
-    pub(crate) docstring: &'static str,
+    pub(crate) docstring: String,
 
     pub(crate) argument_names: &'static [&'static str],
 }
@@ -433,11 +437,11 @@ impl Runtime {
     pub fn register_function<F: RotoFunc>(
         &mut self,
         name: impl Into<String>,
-        f: Func<F>,
+        docstring: String,
+        argument_names: &'static [&'static str],
+        wrapper: F::RustWrapper,
     ) -> Result<(), String> {
-        let docstring = f.docstring();
-        let argument_names = f.argument_names();
-        let description = f.to_function_description();
+        let description = FunctionDescription::of::<F>(wrapper);
         let name = name.into();
 
         Self::check_name(&name)?;
@@ -458,11 +462,11 @@ impl Runtime {
     pub fn register_method<T: 'static, F: RotoFunc>(
         &mut self,
         name: impl Into<String>,
-        f: Func<F>,
+        docstring: String,
+        argument_names: &'static [&'static str],
+        wrapper: F::RustWrapper,
     ) -> Result<(), String> {
-        let docstring = f.docstring();
-        let argument_names = f.argument_names();
-        let description = f.to_function_description();
+        let description = FunctionDescription::of::<F>(wrapper);
         let name = name.into();
 
         Self::check_name(&name)?;
@@ -510,11 +514,11 @@ impl Runtime {
     pub fn register_static_method<T: 'static, F: RotoFunc>(
         &mut self,
         name: impl Into<String>,
-        f: Func<F>,
+        docstring: String,
+        argument_names: &'static [&'static str],
+        wrapper: F::RustWrapper,
     ) -> Result<(), String> {
-        let docstring = f.docstring();
-        let argument_names = f.argument_names();
-        let description = f.to_function_description();
+        let description = FunctionDescription::of::<F>(wrapper);
         let name = name.into();
 
         Self::check_name(&name)?;

--- a/src/runtime/val.rs
+++ b/src/runtime/val.rs
@@ -1,5 +1,37 @@
 use std::ops::{Deref, DerefMut};
 
+/// A wrapper type that makes a registered type safe to pass to and from Roto.
+///
+/// Only types that implement the sealed [`Reflect`] trait can be passed to
+/// Roto. Some primitive types implement this trait directly, but every other
+/// type needs to be wrapped in [`Val`]. You should not wrap the primitives in
+/// [`Val`].
+///
+/// This type implements [`Deref`] and [`DerefMut`] to allow for easy access to
+/// the inner value.
+///
+/// ```rust,ignore
+/// struct Foo {
+///     a: i32,
+///     b: i32,
+/// }
+///
+/// runtime.register_type::<Foo>("..").unwrap();
+///
+/// // compile a script...
+///
+/// // Pass Foo to Roto wrapped in Val:
+/// let f = pkg.get_function::<(), fn(Val<Foo>) -> ()>("main")
+/// f.call(&mut (), Val(Foo { a: 1, b: 2 }));
+///
+/// // For Option and Verdict, wrap the inner type in Val
+/// pkg.get_function::<(), fn(Option<Val<Foo>>) -> ()>("main")
+///
+/// // Do not wrap types that already implement Reflect.
+/// pkg.get_function::<(), fn(i32) -> ()>("main")
+/// ```
+///
+/// [`Reflect`]: super::Reflect
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Val<T>(pub T);

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,1 +1,3 @@
+//! Some tools for working with Roto scripts (currently only printing it)
+
 pub mod print;


### PR DESCRIPTION
- Renamed `Compiled` to `Package`
- Make `Context` unsafe to implement.
- Remove `Func` and change `Runtime::register_{function, static_method, method}` accordingly.
- Make `IrValue` and `Memory` private.
- Make `source_file` and `src` macros private.
- Move `ContextField` to an `__internal` module.
- Document `Val`.
- Redo documentation on `Reflect` with more of a focus on users of Roto.
- Document `Runtime::{compile, add_io_functions}`
- Add context example