### PR TITLE
Change type registration to require `Val`

### DIFF
--- a/examples/addr_range.rs
+++ b/examples/addr_range.rs
@@ -14,11 +14,11 @@ fn main() {
 
     // Register the AddrRange type into Roto with a docstring
     runtime
-        .register_clone_type::<AddrRange>("A range of IP addresses")
+        .register_clone_type::<Val<AddrRange>>("A range of IP addresses")
         .unwrap();
 
     // Register the contains method with a docstring
-    #[roto_method(runtime, AddrRange)]
+    #[roto_method(runtime, Val<AddrRange>)]
     fn contains(range: Val<AddrRange>, addr: Val<IpAddr>) -> bool {
         range.min <= *addr && *addr <= range.max
     }

--- a/examples/optional.rs
+++ b/examples/optional.rs
@@ -15,13 +15,13 @@ fn main() -> Result<(), roto::RotoReport> {
     let mut runtime = Runtime::new();
 
     runtime
-        .register_clone_type_with_name::<NonEmptyString>(
+        .register_clone_type_with_name::<Val<NonEmptyString>>(
             "NonEmptyString",
             "...",
         )
         .unwrap();
 
-    #[roto_static_method(runtime, NonEmptyString)]
+    #[roto_static_method(runtime, Val<NonEmptyString>)]
     fn new(s: Arc<str>) -> Option<Val<NonEmptyString>> {
         if s.is_empty() {
             return None;

--- a/examples/presentation.rs
+++ b/examples/presentation.rs
@@ -75,11 +75,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Registering types and their methods
 
-    rt.register_clone_type_with_name::<RotondaRoute>("Route", "A route")?;
+    rt.register_clone_type_with_name::<Val<RotondaRoute>>(
+        "Route", "A route",
+    )?;
 
-    rt.register_clone_type_with_name::<Log>("Log", "A thing to log to")?;
+    rt.register_clone_type_with_name::<Val<Log>>("Log", "A thing to log to")?;
 
-    #[roto_method(rt, RotondaRoute)]
+    #[roto_method(rt, Val<RotondaRoute>)]
     fn prefix_matches(rr: Val<RotondaRoute>, to_match: Val<Prefix>) -> bool {
         let rr_prefix = match &*rr {
             RotondaRoute::Ipv4Unicast(n) => n.nlri().prefix(),
@@ -92,7 +94,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     #[allow(improper_ctypes_definitions)] // While Asn in inetnum is not FFI-safe
-    #[roto_method(rt, RotondaRoute, aspath_origin)]
+    #[roto_method(rt, Val<RotondaRoute>, aspath_origin)]
     fn rr_aspath_origin(rr: Val<RotondaRoute>, to_match: Asn) -> bool {
         if let Some(hoppath) = rr.attributes().get::<HopPath>() {
             if let Some(Hop::Asn(asn)) = hoppath.origin() {
@@ -103,13 +105,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         false
     }
 
-    #[roto_method(rt, Log)]
+    #[roto_method(rt, Val<Log>)]
     fn log_prefix(mut stream: Val<Log>, prefix: Val<Prefix>) {
         let stream = unsafe { &mut **stream };
         stream.push(Output::Prefix(*prefix));
     }
 
-    #[roto_method(rt, Log)]
+    #[roto_method(rt, Val<Log>)]
     fn log_custom(mut stream: Val<Log>, id: u32, local: u32) {
         let stream = unsafe { &mut **stream };
         stream.push(Output::Custom(id, local));

--- a/examples/runtime.rs
+++ b/examples/runtime.rs
@@ -13,10 +13,10 @@ fn main() -> Result<(), roto::RotoReport> {
     let mut runtime = Runtime::new();
 
     runtime
-        .register_copy_type::<Bla>("Some random type")
+        .register_copy_type::<Val<Bla>>("Some random type")
         .unwrap();
 
-    #[roto_method(runtime, Bla, x)]
+    #[roto_method(runtime, Val<Bla>, x)]
     fn get_x(bla: Val<Bla>) -> u32 {
         bla.x
     }

--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -149,7 +149,7 @@ fn check_roto_type(
                 Err(error_message)
             }
         }
-        TypeDescription::Val(ty) => {
+        TypeDescription::Val(_) => {
             let Type::Name(type_name) = roto_ty else {
                 return Err(error_message);
             };
@@ -160,7 +160,7 @@ fn check_roto_type(
                 return Err(error_message);
             };
 
-            if ty != id {
+            if rust_ty.type_id != id {
                 return Err(error_message);
             }
 

--- a/src/runtime/ty.rs
+++ b/src/runtime/ty.rs
@@ -160,6 +160,10 @@ pub trait Reflect: Sized + seal::Sealed + 'static {
     ///
     /// The information is also returned for direct use.
     fn resolve() -> Ty;
+
+    fn name() -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 pub struct IrValueDoesNotMatchType;
@@ -295,6 +299,10 @@ impl<T: 'static + Clone> Reflect for Val<T> {
 
         let desc = TypeDescription::Val(t);
         TypeRegistry::store::<Self>(desc)
+    }
+
+    fn name() -> &'static str {
+        std::any::type_name::<T>()
     }
 }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -466,8 +466,9 @@ impl TypeChecker {
                 Self::rust_type_to_roto_type(runtime, a)?,
                 Self::rust_type_to_roto_type(runtime, r)?,
             )),
-            TypeDescription::Val(type_id) => {
-                let ident = runtime.get_runtime_type(type_id).unwrap().name();
+            TypeDescription::Val(_) => {
+                let ident =
+                    runtime.get_runtime_type(ty.type_id).unwrap().name();
                 let name = ResolvedName {
                     scope: ScopeRef::GLOBAL,
                     ident: ident.into(),


### PR DESCRIPTION
I was getting into trouble with my code checking the difference between things like `Val<Option<u8>>` and `Option<u8>` because I was treating `Val` as transparent. But sometimes that distinction is important! This conflation is not only confusing to me, but to users too. Understanding `Val` is crucial to using Roto but the inconsistency is not making it obvious when it should be used. My solution is to require `Val` in more places: you register the type with `Val` and then keep it wrapped in `Val` everywhere.

Here's is the diff for the addr_range example to illustrate:
```diff
 runtime
-    .register_clone_type::<AddrRange>("A range of IP addresses")
+    .register_clone_type::<Val<AddrRange>>("A range of IP addresses")
     .unwrap();

 // Register the contains method with a docstring
-#[roto_method(runtime, AddrRange)]
+#[roto_method(runtime, Val<AddrRange>)]
 fn contains(range: Val<AddrRange>, addr: Val<IpAddr>) -> bool {
     range.min <= *addr && *addr <= range.max
 }
```

It's a bit more verbose, but also immediately more consistent.

Of course, this is a massively breaking change.

Closes https://github.com/NLnetLabs/roto/issues/246