### PR TITLE
Allow registering closures

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -107,9 +107,9 @@ pub fn roto_function(attr: TokenStream, item: TokenStream) -> TokenStream {
     let expanded = quote! {
         #function
 
-        #runtime_ident.register_function(
+        #runtime_ident.register_fn(
             stringify!(#name),
-            #docstring.to_string(),
+            #docstring,
             #parameter_names,
             #ident,
         ).unwrap();
@@ -168,7 +168,7 @@ pub fn roto_method(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #runtime_ident.register_method::<#ty, _, _>(
             stringify!(#name),
-            #docstring.to_string(),
+            #docstring,
             #parameter_names,
             #ident
         ).unwrap();
@@ -266,7 +266,7 @@ fn generate_function(item: syn::ItemFn) -> Intermediate {
         })
         .collect();
 
-    let parameter_names = quote!( &[#(stringify!(#args)),*] );
+    let parameter_names = quote!( [#(stringify!(#args)),*] );
 
     Intermediate {
         function: quote!(#item),

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -3353,7 +3353,7 @@ fn register_closure() {
 
     let mut runtime = Runtime::new();
     runtime
-        .register_function("get", "".into(), &[], move || some_number)
+        .register_fn("get", "", [], move || some_number)
         .unwrap();
 
     let s = src!(
@@ -3379,7 +3379,7 @@ fn increment_via_closure() {
 
     let mut runtime = Runtime::new();
     runtime
-        .register_function("inc", "".into(), &[], || {
+        .register_fn("inc", "", [], || {
             COUNTER.fetch_add(1, Ordering::Relaxed);
         })
         .unwrap();

--- a/src/runtime/basic.rs
+++ b/src/runtime/basic.rs
@@ -43,15 +43,15 @@ macro_rules! float_impl {
     ($rt:ident, $t:ty) => {{
         $rt.register_method::<$t, _, _>(
             "floor",
-            "Returns the largest integer less than or equal to self".into(),
-            &["x"],
+            "Returns the largest integer less than or equal to self",
+            ["x"],
             <$t>::floor,
         ).unwrap();
 
         $rt.register_method::<$t, _, _>(
             "ceil",
-            "Returns the smallest integer greater than or equal to self.".into(),
-            &["x"],
+            "Returns the smallest integer greater than or equal to self.",
+            ["x"],
             <$t>::ceil,
         ).unwrap();
 

--- a/src/runtime/basic.rs
+++ b/src/runtime/basic.rs
@@ -41,17 +41,19 @@ macro_rules! float_docs {
 
 macro_rules! float_impl {
     ($rt:ident, $t:ty) => {{
-        /// Returns the largest integer less than or equal to self.
-        #[roto_method($rt, $t, floor)]
-        fn floor(x: $t) -> $t {
-            x.floor()
-        }
+        $rt.register_method::<$t, _, _>(
+            "floor",
+            "Returns the largest integer less than or equal to self".into(),
+            &["x"],
+            <$t>::floor,
+        ).unwrap();
 
-        /// Returns the smallest integer greater than or equal to self.
-        #[roto_method($rt, $t, ceil)]
-        fn ceil(x: $t) -> $t {
-            x.ceil()
-        }
+        $rt.register_method::<$t, _, _>(
+            "ceil",
+            "Returns the smallest integer greater than or equal to self.".into(),
+            &["x"],
+            <$t>::ceil,
+        ).unwrap();
 
         /// Returns the nearest integer to self. If a value is half-way between two integers, round away from 0.0.
         #[roto_method($rt, $t, round)]

--- a/src/runtime/func.rs
+++ b/src/runtime/func.rs
@@ -1,12 +1,17 @@
 use std::any::TypeId;
+use std::mem::MaybeUninit;
+use std::ops::Deref;
+use std::sync::Arc;
 
-use crate::codegen::check::{RotoFunc, RustIrFunction};
+use crate::lir::{IrValue, Memory};
+use crate::Reflect;
 
 #[derive(Clone)]
 pub struct FunctionDescription {
     parameter_types: Vec<TypeId>,
     return_type: TypeId,
     pointer: *const u8,
+    trampoline: *const u8,
     ir_function: RustIrFunction,
 }
 
@@ -17,17 +22,33 @@ pub struct FunctionDescription {
 unsafe impl Send for FunctionDescription {}
 unsafe impl Sync for FunctionDescription {}
 
+pub trait RegisterableFn<A, R>: Send + 'static {
+    /// The type of a Rust function wrapping a function of this type
+    type RustWrapper;
+
+    const TRAMPOLINE: Self::RustWrapper;
+
+    fn ptr(self) -> *const u8;
+    fn parameter_types(&self) -> Vec<TypeId>;
+    fn return_type() -> TypeId;
+
+    fn ir_function(&self) -> RustIrFunction;
+}
+
 impl FunctionDescription {
-    pub fn of<F: RotoFunc>(wrapper: &F::RustWrapper) -> Self {
-        let parameter_types = F::parameter_types();
+    pub fn of<A, R, F: RegisterableFn<A, R>>(func: F) -> Self {
+        let parameter_types = func.parameter_types();
         let return_type = F::return_type();
-        let pointer = F::ptr(wrapper);
-        let ir_function = F::ir_function(wrapper);
+        let trampoline_ptr = &F::TRAMPOLINE as *const _ as *const *const u8;
+        let trampoline = unsafe { *trampoline_ptr };
+        let ir_function = func.ir_function();
+        let pointer = func.ptr();
 
         Self {
             parameter_types,
             return_type,
             pointer,
+            trampoline,
             ir_function,
         }
     }
@@ -46,6 +67,10 @@ impl FunctionDescription {
 
     pub fn ir_function(&self) -> RustIrFunction {
         self.ir_function.clone()
+    }
+
+    pub fn trampoline(&self) -> *const u8 {
+        self.trampoline
     }
 }
 
@@ -69,3 +94,94 @@ impl std::fmt::Debug for FunctionDescription {
             .finish()
     }
 }
+
+#[allow(clippy::type_complexity)]
+#[derive(Clone)]
+pub struct RustIrFunction(Arc<dyn Fn(&mut Memory, Vec<IrValue>)>);
+
+impl Deref for RustIrFunction {
+    type Target = Arc<dyn Fn(&mut Memory, Vec<IrValue>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+macro_rules! registerable_fn {
+    (fn($($a:ident),*) -> $r:ident) => {
+        #[allow(non_snake_case)]
+        #[allow(unused_variables)]
+        #[allow(unused_mut)]
+        impl<$($a,)* $r, F> RegisterableFn<($($a,)*), $r> for F
+        where
+            $($a: Reflect,)*
+            $r: Reflect,
+            F: Fn($($a,)*) -> $r + Send + 'static,
+        {
+            type RustWrapper = extern "C" fn (*const Self, *mut $r::Transformed, $($a::AsParam),*) -> ();
+
+            const TRAMPOLINE: Self::RustWrapper = {
+                extern "C" fn foo<$($a: Reflect,)* $r: Reflect>(x: *const impl Fn($($a,)*) -> $r, out: *mut $r::Transformed, $($a: $a::AsParam),*) -> () {
+                    let res = (unsafe { &*x })(
+                        $(<$a as Reflect>::untransform(<$a as Reflect>::to_value($a)),)*
+                    );
+                    let res_transformed  = <$r as Reflect>::transform(res);
+                    unsafe { std::ptr::write(out, res_transformed) };
+                }
+                foo
+            };
+
+            fn ptr(self) -> *const u8 {
+                let ptr = Box::leak(Box::new(self));
+                ptr as *const _ as *const u8
+            }
+
+            fn parameter_types(&self) -> Vec<TypeId> {
+                vec![$($a::resolve().type_id,)*]
+            }
+
+            fn return_type() -> TypeId {
+                $r::resolve().type_id
+            }
+
+            fn ir_function(&self) -> RustIrFunction {
+                let f = self as *const _;
+                // We reuse the type names as variable names, so they are
+                // uppercase, but that's the easiest way to do this.
+                #[allow(non_snake_case)]
+                let f = move |mem: &mut Memory, args: Vec<IrValue>| {
+                    let [$r, $($a),*]: &[IrValue] = &args else {
+                        panic!("Number of arguments is not correct")
+                    };
+
+                    let &IrValue::Pointer($r) = $r else {
+                        panic!("Out pointer is not a pointer")
+                    };
+                    let $r = mem.get($r);
+
+                    $(
+                        let Ok($a) = <$a as Reflect>::from_ir_value(mem, $a.clone()) else {
+                            panic!("Type of argument is not correct: {}", $a)
+                        };
+                    )*
+                    let mut uninit_ret = MaybeUninit::<<$r as Reflect>::Transformed>::uninit();
+                    Self::TRAMPOLINE(
+                        f,
+                        $r as *mut <$r as Reflect>::Transformed,
+                        $($a),*
+                    );
+                };
+                RustIrFunction(Arc::new(f))
+            }
+        }
+    }
+}
+
+registerable_fn!(fn() -> R);
+registerable_fn!(fn(A1) -> R);
+registerable_fn!(fn(A1, A2) -> R);
+registerable_fn!(fn(A1, A2, A3) -> R);
+registerable_fn!(fn(A1, A2, A3, A4) -> R);
+registerable_fn!(fn(A1, A2, A3, A4, A5) -> R);
+registerable_fn!(fn(A1, A2, A3, A4, A5, A6) -> R);
+registerable_fn!(fn(A1, A2, A3, A4, A5, A6, A7) -> R);


### PR DESCRIPTION
- Rename `register_function` to `register_fn`
- `register_{fn, static_method, method}` now take regular function-like values (including `'static` closures), instead of `extern "C"` functions.
- This makes the macros kind of unnecessary, but we keep them for backwards compatibility and a bit of convenience.
- `RotoFunc` is now split from `RegisterableFn`
- Changed the parameter types to `register_{fn, static_method, method}` to be a bit more lenient.
- Since registered functions can now carry data, we need to drop them properly, so we add them to the `SharedModuleData`.