### PR TITLE
Fallible `FileTree` methods

### DIFF
--- a/src/file_tree_tests.rs
+++ b/src/file_tree_tests.rs
@@ -1,28 +1,21 @@
 use std::path::Path;
 
-use crate::file_tree::{FileTree, FileTreeError, SourceFile};
+use crate::file_tree::{FileTree, SourceFile};
 
 #[test]
 fn source_file_try_read_empty_file() {
-    let source = SourceFile::try_read(Path::new(""));
-    let err = source.unwrap_err();
-
-    assert!(matches!(err, FileTreeError::PathNotFound));
+    let source = SourceFile::read(Path::new(""));
+    let _err = source.unwrap_err();
 }
 
 #[test]
 fn source_file_try_read_nonexistent_file() {
-    let source =
-        SourceFile::try_read(Path::new("/non-existent/file/pkg.roto"));
-    let err = source.unwrap_err();
-
-    assert!(matches!(err, FileTreeError::IOError(_)));
+    let source = SourceFile::read(Path::new("/non-existent/file/pkg.roto"));
+    let _err = source.unwrap_err();
 }
 
 #[test]
 fn file_tree_try_single_file() {
-    let tree = FileTree::try_single_file("");
-    let err = tree.unwrap_err();
-
-    assert!(matches!(err, FileTreeError::PathNotFound));
+    let tree = FileTree::single_file("");
+    let _err = tree.unwrap_err();
 }

--- a/src/file_tree_tests.rs
+++ b/src/file_tree_tests.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+
+use crate::file_tree::{FileTree, FileTreeError, SourceFile};
+
+#[test]
+fn source_file_try_read_empty_file() {
+    let source = SourceFile::try_read(Path::new(""));
+    let err = source.unwrap_err();
+
+    assert!(matches!(err, FileTreeError::PathNotFound));
+}
+
+#[test]
+fn source_file_try_read_nonexistent_file() {
+    let source =
+        SourceFile::try_read(Path::new("/non-existent/file/pkg.roto"));
+    let err = source.unwrap_err();
+
+    assert!(matches!(err, FileTreeError::IOError(_)));
+}
+
+#[test]
+fn file_tree_try_single_file() {
+    let tree = FileTree::try_single_file("");
+    let err = tree.unwrap_err();
+
+    assert!(matches!(err, FileTreeError::PathNotFound));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod ast;
 mod cli;
 mod codegen;
 mod file_tree;
+#[cfg(test)]
+mod file_tree_tests;
 mod ir_printer;
 mod label;
 mod lir;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -43,11 +43,14 @@ pub enum RotoError {
     Read(String, std::io::Error),
     Parse(ParseError),
     Type(TypeError),
+    TestsFailed(),
+    CouldNotRetrieveFunction(FunctionRetrievalError),
 }
 
 /// An error report containing a set of Roto errors.
 ///
 /// The errors can be printed with the regular [`std::fmt::Display`].
+#[derive(Default)]
 pub struct RotoReport {
     pub files: Vec<SourceFile>,
     pub errors: Vec<RotoError>,
@@ -117,7 +120,7 @@ impl RotoReport {
         for error in &self.errors {
             match error {
                 RotoError::Read(name, io) => {
-                    write!(f, "could not open `{name}`: {io}")?;
+                    write!(f, "Could not read file `{name}`: {io}")?;
                 }
                 RotoError::Parse(error) => {
                     let label_message = error.kind.label();
@@ -179,6 +182,12 @@ impl RotoReport {
                     report.write(&mut file_cache, &mut v).unwrap();
                     let s = String::from_utf8_lossy(&v);
                     write!(f, "{s}")?;
+                }
+                RotoError::TestsFailed() => {
+                    write!(f, "Tests failed")?;
+                }
+                RotoError::CouldNotRetrieveFunction(e) => {
+                    write!(f, "Could not retrieve function: {e}")?;
                 }
             }
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -25,7 +25,7 @@ use ty::{Reflect, Ty, TypeDescription, TypeRegistry};
 
 use crate::{
     ast::Identifier,
-    file_tree::{FileTree, FileTreeError},
+    file_tree::FileTree,
     parser::token::{Lexer, Token},
     runtime::func::RegisterableFn,
     Context, Package, RotoReport,
@@ -78,12 +78,6 @@ pub struct Runtime {
     constants: HashMap<Identifier, RuntimeConstant>,
 }
 
-#[derive(Debug)]
-pub enum RuntimeCompileError {
-    FileTree(FileTreeError),
-    Report(RotoReport),
-}
-
 impl Runtime {
     /// Compile a script from a path and return the result.
     ///
@@ -93,17 +87,7 @@ impl Runtime {
         &self,
         path: impl AsRef<Path>,
     ) -> Result<Package, RotoReport> {
-        FileTree::read(path).compile(self)
-    }
-
-    pub fn try_compile(
-        &self,
-        path: impl AsRef<Path>,
-    ) -> Result<Package, RuntimeCompileError> {
-        FileTree::try_read(path)
-            .map_err(RuntimeCompileError::FileTree)?
-            .compile(self)
-            .map_err(RuntimeCompileError::Report)
+        FileTree::read(path)?.compile(self)
     }
 }
 

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -8,7 +8,7 @@ fn parse_errors() {
         let runtime = Runtime::new();
 
         let relative_path = path.strip_prefix(&root).unwrap();
-        let file_tree = FileTree::read(relative_path);
+        let file_tree = FileTree::read(relative_path).unwrap();
         let res = file_tree.compile(&runtime);
         let Err(e) = res else {
             panic!("should not succeed");
@@ -26,7 +26,7 @@ fn type_errors() {
         let runtime = Runtime::new();
 
         let relative_path = path.strip_prefix(&root).unwrap();
-        let file_tree = FileTree::read(relative_path);
+        let file_tree = FileTree::read(relative_path).unwrap();
         let res = file_tree.compile(&runtime);
         let Err(e) = res else {
             panic!("should not succeed");


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/249. Built upon a patch sent by @algernon.

Makes the following functions fallible instead of panicking:
- Public:
  - `SourceFile::read`
  - `FileTree::read`
  - `FileTree::single_file`
  - `FileTree::directory`
- Private:
  - `FileTree::process_subdir`
  - `FileTree::find_files`

Changes from @algernon's patch:
 - I made all these files return a regular `RotoReport` instead of a separate error. This integrates them nicely with other functions and cleans some things up.
 - I didn't keep the `try_*` variants of the functions they had. They didn't want to break the original (panicking) API, but I feel like these errors are frequent enough to warrant proper handling. Migration should be easy too: just add an unwrap.

Thanks @algernon!