### PR TITLE
Make the trailing comma of match expressions optional

### DIFF
--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -698,7 +698,13 @@ impl Parser<'_, '_> {
                 exprs
             } else {
                 let expr = self.expr()?;
-                self.take(Token::Comma)?;
+
+                // If this is not the last item, we require a comma, if it is
+                // the last one, (i.e. if we get a `}` next), we don't need it.
+                if !self.peek_is(Token::CurlyRight) {
+                    self.take(Token::Comma)?;
+                }
+
                 Meta {
                     id: expr.id,
                     node: Block {

--- a/src/parser/test_expressions.rs
+++ b/src/parser/test_expressions.rs
@@ -171,3 +171,46 @@ fn hex_number() {
     let s = "0xffff029";
     parse_expr(s).unwrap();
 }
+
+#[test]
+fn match_without_trailing_comma() {
+    let s = "
+      match s {
+          Foo -> 10,
+          Bar -> 20
+      }
+    ";
+    parse_expr(s).unwrap();
+}
+
+#[test]
+fn match_with_trailing_comma() {
+    let s = "
+      match s {
+          Foo -> 10,
+          Bar -> 20,
+      }
+    ";
+    parse_expr(s).unwrap();
+}
+
+#[test]
+fn match_with_braces_and_commas() {
+    let s = "
+      match s {
+          Foo -> { 10 },
+          Bar -> { 20 },
+      }
+    ";
+    parse_expr(s).unwrap();
+}
+#[test]
+fn match_with_braces_without_commas() {
+    let s = "
+      match s {
+          Foo -> { 10 }
+          Bar -> { 20 }
+      }
+    ";
+    parse_expr(s).unwrap();
+}


### PR DESCRIPTION
@DRiKE 