### PR TITLE
feat(cli): Allow running roto functions other than 'main'

### DIFF
--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -13,7 +13,7 @@ Commands
 ``test``
     Test a script
 ``run``
-    Run a script
+    Run a script's function. ``main`` by default, but a function name can be provided.
 ``print``
     Print a Roto file with syntax highlighting
 ``help``

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,7 @@ enum Command {
 ///  - `doc`: generate documentation
 ///  - `check`: type check a script
 ///  - `test`: run tests for a script
-///  - `run`: run the a function of a script
+///  - `run`: run a function of a script
 pub fn cli(rt: &Runtime) {
     match cli_inner(rt) {
         Ok(()) => std::process::exit(0),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,10 +31,12 @@ enum Command {
         #[arg()]
         file: PathBuf,
     },
-    /// Run a script
+    /// Run a script's function
     Run {
         #[arg()]
         file: PathBuf,
+        #[arg(default_value = "main")]
+        function: String,
     },
     /// Print a Roto file with syntax highlighting
     Print {
@@ -52,7 +54,7 @@ enum Command {
 ///  - `doc`: generate documentation
 ///  - `check`: type check a script
 ///  - `test`: run tests for a script
-///  - `run`: run the main function of a script
+///  - `run`: run the a function of a script
 pub fn cli(rt: &Runtime) {
     match cli_inner(rt) {
         Ok(()) => std::process::exit(0),
@@ -89,7 +91,7 @@ fn cli_inner(rt: &Runtime) -> Result<(), RotoReport> {
                 });
             }
         }
-        Command::Run { file } => {
+        Command::Run { file, function } => {
             let mut p = FileTree::read(file)?
                 .parse()?
                 .typecheck(rt)?
@@ -97,7 +99,7 @@ fn cli_inner(rt: &Runtime) -> Result<(), RotoReport> {
                 .lower_to_lir()
                 .codegen();
 
-            let f = p.get_function::<(), fn()>("main").map_err(|e| {
+            let f = p.get_function::<(), fn()>(function).map_err(|e| {
                 RotoReport {
                     errors: vec![RotoError::CouldNotRetrieveFunction(e)],
                     ..Default::default()


### PR DESCRIPTION
This PR allows calling functions from .roto scripts by name.
