### PR TITLE
Impl Error for error types

### DIFF
--- a/src/codegen/check.rs
+++ b/src/codegen/check.rs
@@ -58,6 +58,8 @@ impl Display for FunctionRetrievalError {
     }
 }
 
+impl std::error::Error for FunctionRetrievalError {}
+
 pub fn check_roto_type_reflect<T: Reflect>(
     type_info: &mut TypeInfo,
     roto_ty: &Type,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub(crate) use pipeline::{source_file, src};
 
 pub use codegen::TypedFunc;
 pub use file_tree::{FileSpec, FileTree, SourceFile};
-pub use pipeline::{Package, RotoError, RotoReport};
+pub(crate) use pipeline::RotoError;
+pub use pipeline::{Package, RotoReport};
 pub use roto_macros::{
     roto_function, roto_method, roto_static_method, Context,
 };

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -39,7 +39,7 @@ use log::info;
 
 /// An error from a compilation of a Roto script.
 #[derive(Debug)]
-pub enum RotoError {
+pub(crate) enum RotoError {
     Read(String, std::io::Error),
     Parse(ParseError),
     Type(TypeError),
@@ -49,11 +49,11 @@ pub enum RotoError {
 
 /// An error report containing a set of Roto errors.
 ///
-/// The errors can be printed with the regular [`std::fmt::Display`].
+/// The report can be printed with the regular [`std::fmt::Display`].
 #[derive(Default)]
 pub struct RotoReport {
     pub files: Vec<SourceFile>,
-    pub errors: Vec<RotoError>,
+    pub(crate) errors: Vec<RotoError>,
     pub spans: Spans,
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -390,6 +390,8 @@ impl std::fmt::Display for RegistrationError {
     }
 }
 
+impl std::error::Error for RegistrationError {}
+
 impl Runtime {
     pub(crate) fn get_function(
         &self,


### PR DESCRIPTION
Implements the `std::error::Error` trait for `RotoError`, `TypeError`, `RegistrationError`, and `FunctionRetrievalError` so that they play nice with crates like [anyhow](https://crates.io/crates/anyhow). This also means the doc comment for `RotoReport` is no long misleading (`RotoError`s did not implement `std::fmt::Display` until now).

`RotoError::Parse(ParseError)` and `RotoError::Type(TypeError)` actually have some extra handling in `RotoReport::write`. However,  `RotoError` doesn't store the necessary span information in order to emulate that extra handling, so I just forward to their individual `Display` implementations.

For `TypeError`, I just wrote the `description` to the formatter (kind of similar to how `ParseError` already handles it) since I wasn't sure how to handle  `Vec<Label>>`.
