### PR TITLE
Delay resolving `to_string` for f-strings

### DIFF
--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1312,6 +1312,82 @@ fn unicode_val_in_f_string() {
 }
 
 #[test]
+fn f_string_and_int_var_1() {
+    let s = src!(
+        r#"
+        fn foo() -> String {
+            let x = 10;
+            f"This should just work: {x}"
+        }
+        "#
+    );
+
+    let mut p = compile(s);
+    let f = p.get_function::<(), fn() -> Arc<str>>("foo").unwrap();
+
+    let res = f.call(&mut ());
+    assert_eq!(res, "This should just work: 10".into());
+}
+
+#[test]
+fn f_string_and_int_var_2() {
+    let s = src!(
+        r#"
+        fn foo() -> String {
+            let x = 10;
+            let s = f"This should just work: {x}";
+            let y: u8 = x;
+            s
+        }
+        "#
+    );
+
+    let mut p = compile(s);
+    let f = p.get_function::<(), fn() -> Arc<str>>("foo").unwrap();
+
+    let res = f.call(&mut ());
+    assert_eq!(res, "This should just work: 10".into());
+}
+
+#[test]
+fn f_string_and_float_var_1() {
+    let s = src!(
+        r#"
+        fn foo() -> String {
+            let x = 10.0;
+            f"This should just work: {x}"
+        }
+        "#
+    );
+
+    let mut p = compile(s);
+    let f = p.get_function::<(), fn() -> Arc<str>>("foo").unwrap();
+
+    let res = f.call(&mut ());
+    assert_eq!(res, "This should just work: 10".into());
+}
+
+#[test]
+fn f_string_and_float_var_2() {
+    let s = src!(
+        r#"
+        fn foo() -> String {
+            let x = 10.0;
+            let s = f"This should just work: {x}";
+            let y: f32 = x;
+            s
+        }
+        "#
+    );
+
+    let mut p = compile(s);
+    let f = p.get_function::<(), fn() -> Arc<str>>("foo").unwrap();
+
+    let res = f.call(&mut ());
+    assert_eq!(res, "This should just work: 10".into());
+}
+
+#[test]
 fn arc_type() {
     use std::sync::atomic::Ordering;
 

--- a/src/typechecker/function.rs
+++ b/src/typechecker/function.rs
@@ -49,6 +49,7 @@ impl TypeChecker {
         };
 
         self.block(scope, &ctx, body)?;
+        self.resolve_obligations()?;
 
         let param_types = params.into_iter().map(|(_, t)| t).collect();
 
@@ -91,6 +92,8 @@ impl TypeChecker {
         };
 
         self.block(scope, &ctx, body)?;
+        self.resolve_obligations()?;
+
         Ok(())
     }
 
@@ -131,6 +134,7 @@ impl TypeChecker {
             function_return_type: Some(ret),
         };
         self.block(scope, &ctx, body)?;
+        self.resolve_obligations()?;
         Ok(())
     }
 

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -31,6 +31,14 @@ impl Type {
         Type::named("u8", Vec::new())
     }
 
+    pub fn i32() -> Type {
+        Type::named("i32", Vec::new())
+    }
+
+    pub fn f64() -> Type {
+        Type::named("f64", Vec::new())
+    }
+
     pub fn string() -> Type {
         Type::named("String", Vec::new())
     }


### PR DESCRIPTION
Fixes a part of https://github.com/NLnetLabs/roto/issues/244 in the direction that everyone seems to prefer. This does **not** automatically implement `to_string` for all types, but instead delays resolving that method to the end of the function body. If the type of an integer or float literal is not resolved by then, we make the assumption that it is `i32` or `f64`, respectively, like the lowering to MIR already does.

This is backwards compatible and should go into 0.8.1.