### PR TITLE
Use dtolnays hack to make `TypedFunc` callable

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,15 +21,15 @@ fn main() -> ExitCode {
         .get_function::<fn(IpAddr) -> Verdict<(), ()>>("main")
         .unwrap();
 
-    let res = func.call("0.0.0.0".parse().unwrap());
+    let res = func("0.0.0.0".parse().unwrap());
     println!("main(0.0.0.0) = {res:?}");
 
-    let res = func.call("1.1.1.1".parse().unwrap());
+    let res = func("1.1.1.1".parse().unwrap());
     println!("main(1.1.1.1) = {res:?}");
 
     let is_zero = pkg.get_function::<fn(IpAddr) -> bool>("is_zero").unwrap();
 
-    let res = is_zero.call("0.0.0.0".parse().unwrap());
+    let res = is_zero("0.0.0.0".parse().unwrap());
     println!("is_zero(0.0.0.0) = {res:?}");
 
     println!();


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/275.

Still not sure whether this is a good idea 😄 Opinions welcome.