### PR TITLE
Rename type -> struct

### DIFF
--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -353,7 +353,7 @@ fn a_bunch_of_comparisons() {
 fn record() {
     let s = src!(
         "
-        type Foo { a: i32, b: i32 }
+        struct Foo { a: i32, b: i32 }
 
         filtermap main(x: i32) {
             let foo = Foo { a: x, b: 20 };
@@ -386,7 +386,7 @@ fn record() {
 fn record_with_fields_flipped() {
     let s = src!(
         "
-        type Foo { a: i32, b: i32 }
+        struct Foo { a: i32, b: i32 }
 
         filtermap main(x: i32) {
             # These are flipped, to ensure that the order in which
@@ -422,8 +422,8 @@ fn record_with_fields_flipped() {
 fn nested_record() {
     let s = src!(
         "
-        type Foo { x: Bar, y: Bar }
-        type Bar { a: i32, b: i32 }
+        struct Foo { x: Bar, y: Bar }
+        struct Bar { a: i32, b: i32 }
 
         filtermap main(x: i32) {
             let bar = Bar { a: 20, b: x };
@@ -458,7 +458,7 @@ fn misaligned_fields() {
     // A record where the second field should be aligned
     let s = src!(
         "
-        type Foo { a: i16, b: i32 }
+        struct Foo { a: i16, b: i32 }
 
         filtermap main(x: i32) {
             let foo = Foo { a: 10, b: x };
@@ -2662,7 +2662,7 @@ fn use_type_from_module() {
     let foo = source_file!(
         "foo",
         "
-            type Foo {
+            struct Foo {
                 bar: i32,
             }
         "
@@ -2693,7 +2693,7 @@ fn use_imported_type() {
     let foo = source_file!(
         "foo",
         "
-            type Foo {
+            struct Foo {
                 bar: i32,
             }
         "
@@ -2726,7 +2726,7 @@ fn use_type_in_function_argument() {
     let foo = source_file!(
         "foo",
         "
-            type Foo {
+            struct Foo {
                 bar: i32,
             }
         "
@@ -2793,7 +2793,7 @@ fn use_type_in_function_return_type() {
     let foo = source_file!(
         "foo",
         "
-            type Foo {
+            struct Foo {
                 bar: i32,
             }
         "
@@ -2814,7 +2814,7 @@ fn use_type_from_other_module_in_type() {
     let pkg = source_file!(
         "pkg",
         "
-            type Bli {
+            struct Bli {
                 bla: foo.Bla,
             }
 
@@ -2826,7 +2826,7 @@ fn use_type_from_other_module_in_type() {
     let foo = source_file!(
         "foo",
         "
-            type Bla {
+            struct Bla {
                 blubb: i32,
             }
         "

--- a/src/lir/test_eval.rs
+++ b/src/lir/test_eval.rs
@@ -290,7 +290,7 @@ fn anonymous_record() {
 fn typed_record() {
     let s = src!(
         "
-        type Range {
+        struct Range {
             low: u32,
             high: u32,
         }
@@ -330,8 +330,8 @@ fn typed_record() {
 fn nested_record() {
     let s = src!(
         "
-        type Foo { x: Bar, y: Bar }
-        type Bar { a: i32, b: i32 }
+        struct Foo { x: Bar, y: Bar }
+        struct Bar { a: i32, b: i32 }
 
         filtermap main(x: i32) {
             let bar = Bar { a: 20, b: x };

--- a/src/parser/filter_map.rs
+++ b/src/parser/filter_map.rs
@@ -83,7 +83,7 @@ impl Parser<'_, '_> {
     pub(super) fn record_type_assignment(
         &mut self,
     ) -> ParseResult<RecordTypeDeclaration> {
-        self.take(Token::Keyword(Keyword::Type))?;
+        self.take(Token::Keyword(Keyword::Struct))?;
         let ident = self.identifier()?;
         let record_type = self.record_type()?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -206,7 +206,7 @@ impl<'source, 'spans> Parser<'source, 'spans> {
             Token::Keyword(Keyword::FilterMap | Keyword::Filter) => {
                 Declaration::FilterMap(Box::new(self.filter_map()?))
             }
-            Token::Keyword(Keyword::Type) => {
+            Token::Keyword(Keyword::Struct) => {
                 Declaration::Record(self.record_type_assignment()?)
             }
             Token::Keyword(Keyword::Fn) => {
@@ -278,8 +278,6 @@ impl Parser<'_, '_> {
         let (token, span) = self.next()?;
         let ident = match token {
             Token::Ident(s) => s,
-            // 'contains' and `type` is already used as both a keyword and an identifier
-            Token::Keyword(Keyword::Type) => "type",
             Token::Keyword(_) => {
                 let note = format!(
                     "`{token}` is a keyword and cannot be used as an identifier."

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -86,9 +86,9 @@ pub enum Keyword {
     Reject,
     Return,
     Std,
+    Struct,
     Super,
     Test,
-    Type,
     While,
 }
 
@@ -513,9 +513,9 @@ impl<'s> Lexer<'s> {
             "reject" => Keyword::Reject,
             "return" => Keyword::Return,
             "std" => Keyword::Std,
+            "struct" => Keyword::Struct,
             "super" => Keyword::Super,
             "test" => Keyword::Test,
-            "type" => Keyword::Type,
             "while" => Keyword::While,
             // ----
             "true" => return ControlFlow::Break((Token::Bool(true), span)),
@@ -602,9 +602,9 @@ impl Keyword {
             Keyword::Reject => "reject",
             Keyword::Return => "return",
             Keyword::Std => "std",
+            Keyword::Struct => "struct",
             Keyword::Super => "super",
             Keyword::Test => "test",
-            Keyword::Type => "type",
             Keyword::While => "while",
         }
     }

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -40,7 +40,7 @@ fn empty() {
 
 #[test]
 fn one_record() {
-    let s = src!("type Foo { a: u32 }");
+    let s = src!("struct Foo { a: u32 }");
     assert!(typecheck(s).is_ok());
 }
 
@@ -48,8 +48,8 @@ fn one_record() {
 fn declared_multiple_times() {
     let s = src!(
         "
-        type Foo { a: u32 }
-        type Foo { a: u32 }
+        struct Foo { a: u32 }
+        struct Foo { a: u32 }
     "
     );
     assert!(typecheck(s).is_err());
@@ -59,7 +59,7 @@ fn declared_multiple_times() {
 fn double_field() {
     let s = src!(
         "
-        type Foo { a: u32, a: u8 }
+        struct Foo { a: u32, a: u8 }
     "
     );
     assert!(typecheck(s).is_err());
@@ -67,7 +67,7 @@ fn double_field() {
 
 #[test]
 fn undeclared_type_in_record() {
-    let s = src!("type Bar { f: Foo }");
+    let s = src!("struct Bar { f: Foo }");
     assert!(typecheck(s).is_err());
 }
 
@@ -75,7 +75,7 @@ fn undeclared_type_in_record() {
 fn nested_record() {
     let s = src!(
         "
-        type Foo { a: { b: u32, c: u32 } }
+        struct Foo { a: { b: u32, c: u32 } }
     "
     );
     assert!(typecheck(s).is_ok());
@@ -85,16 +85,16 @@ fn nested_record() {
 fn two_records() {
     let s = src!(
         "
-        type Foo { a: u32 }
-        type Bar { f: Foo }
+        struct Foo { a: u32 }
+        struct Bar { f: Foo }
     "
     );
     assert!(typecheck(s).is_ok());
 
     let s = src!(
         "
-        type Bar { f: Foo }
-        type Foo { a: u32 }
+        struct Bar { f: Foo }
+        struct Foo { a: u32 }
     "
     );
     assert!(typecheck(s).is_ok());
@@ -104,35 +104,35 @@ fn two_records() {
 fn record_cycle() {
     let s = src!(
         "
-        type Foo { f: Foo }
+        struct Foo { f: Foo }
     "
     );
     assert!(typecheck(s).is_err());
 
     let s = src!(
         "
-        type Bar { f: Foo }
-        type Foo { b: Bar }
+        struct Bar { f: Foo }
+        struct Foo { b: Bar }
     "
     );
     assert!(typecheck(s).is_err());
 
     let s = src!(
         "
-        type A { x: B }
-        type B { x: C }
-        type C { x: D }
-        type D { x: A }
+        struct A { x: B }
+        struct B { x: C }
+        struct C { x: D }
+        struct D { x: A }
     "
     );
     assert!(typecheck(s).is_err());
 
     let s = src!(
         "
-        type A { x: B }
-        type B { x: C }
-        type C { x: { y: D } }
-        type D { x: B }
+        struct A { x: B }
+        struct B { x: C }
+        struct C { x: { y: D } }
+        struct D { x: B }
     "
     );
     assert!(typecheck(s).is_err());
@@ -142,10 +142,10 @@ fn record_cycle() {
 fn record_diamond() {
     let s = src!(
         "
-        type A { x: B, y: C }
-        type B { x: D }
-        type C { x: D }
-        type D { }
+        struct A { x: B, y: C }
+        struct B { x: D }
+        struct C { x: D }
+        struct D { }
     "
     );
     assert!(typecheck(s).is_ok());
@@ -239,7 +239,7 @@ fn filter_map_double_definition() {
 fn using_records() {
     let s = src!(
         r#"
-        type Foo { a: String }
+        struct Foo { a: String }
 
         filtermap bar(r: u32) {
             let a = Foo { a: "hello" };
@@ -251,7 +251,7 @@ fn using_records() {
 
     let s = src!(
         r#"
-        type Foo { a: String }
+        struct Foo { a: String }
 
         filtermap bar(r: u32) {
             let a = Foo { a: 0.0.0.0 };
@@ -263,7 +263,7 @@ fn using_records() {
 
     let s = src!(
         r#"
-        type Foo { a: string }
+        struct Foo { a: string }
 
         filtermap bar(r: u32) {
             let a = Foo { };
@@ -317,7 +317,7 @@ fn let_type_annotation() {
 fn integer_inference() {
     let s = src!(
         "
-        type Foo { x: u8 }
+        struct Foo { x: u8 }
 
         filtermap my_map(r: u32) {
             let foo = Foo { x: 5 };
@@ -329,8 +329,8 @@ fn integer_inference() {
 
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u8 }
+        struct Foo { x: u8 }
+        struct Bar { x: u8 }
 
         filtermap my_map(r: u32) {
             let a = 5;
@@ -343,8 +343,8 @@ fn integer_inference() {
 
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u8 }
+        struct Foo { x: u8 }
+        struct Bar { x: u8 }
 
         filtermap my_map(r: u32) {
             let a = 5;
@@ -358,8 +358,8 @@ fn integer_inference() {
 
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u32 }
+        struct Foo { x: u8 }
+        struct Bar { x: u32 }
 
         filtermap my_map(r: u32) {
             let a = 5;
@@ -373,8 +373,8 @@ fn integer_inference() {
 
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u32 }
+        struct Foo { x: u8 }
+        struct Bar { x: u32 }
 
         filtermap my_map(r: u32) {
             let foo = Foo { x: 5 };
@@ -390,8 +390,8 @@ fn integer_inference() {
 fn assign_field_to_other_record() {
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u8 }
+        struct Foo { x: u8 }
+        struct Bar { x: u8 }
 
         filtermap my_map(r: u32) {
             let foo = Foo { x: 5 };
@@ -404,8 +404,8 @@ fn assign_field_to_other_record() {
 
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u8 }
+        struct Foo { x: u8 }
+        struct Bar { x: u8 }
 
         filtermap my_map(r: u32) {
             let foo = Foo { x: 5 };
@@ -418,8 +418,8 @@ fn assign_field_to_other_record() {
 
     let s = src!(
         "
-        type Foo { x: u8 }
-        type Bar { x: u32 }
+        struct Foo { x: u8 }
+        struct Bar { x: u32 }
 
         filtermap my_map(r: u32) {
             let foo = Foo { x: 5 };
@@ -567,7 +567,7 @@ fn send_output_stream() {
             foo: String
         }
 
-        type Bar { bar: String }
+        struct Bar { bar: String }
 
         fn hello() {
             stream.send(Bar {
@@ -674,7 +674,7 @@ fn record_inference() {
 
     let s = src!(
         "
-        type A { a: u32 }
+        struct A { a: u32 }
 
         fn bla(a: A, b: A) -> Bool {
             a == b
@@ -694,8 +694,8 @@ fn record_inference() {
 
     let s = src!(
         "
-        type A { a: u32 }
-        type B { a: u32 }
+        struct A { a: u32 }
+        struct B { a: u32 }
 
         fn bla() -> Bool {
             a == b && a == c
@@ -1091,7 +1091,7 @@ fn assignment_to_record() {
 fn invalid_type_in_f_string() {
     let s = src!(
         r#"
-            type Foo {
+            struct Foo {
                 x: i32,
             }
 

--- a/tests/scripts/type_errors/duplicate_fields.roto
+++ b/tests/scripts/type_errors/duplicate_fields.roto
@@ -1,4 +1,4 @@
-type Foo { a: u32, a: u32 }
+struct Foo { a: u32, a: u32 }
 
 filter foo() {
 	accept

--- a/tests/scripts/type_errors/field_does_not_exist.roto
+++ b/tests/scripts/type_errors/field_does_not_exist.roto
@@ -1,4 +1,4 @@
-type Foo { a: u32 }
+struct Foo { a: u32 }
 
 fn foo() {
     let foo = Foo { a: 8 };

--- a/tests/scripts/type_errors/match_on_record.roto
+++ b/tests/scripts/type_errors/match_on_record.roto
@@ -1,4 +1,4 @@
-type Foo { a: u32 }
+struct Foo { a: u32 }
 
 filter foo(msg: Foo) {
 	match msg {}

--- a/tests/scripts/type_errors/missing_fields.roto
+++ b/tests/scripts/type_errors/missing_fields.roto
@@ -1,4 +1,4 @@
-type Foo { a: u32, b: u32, c: u32 }
+struct Foo { a: u32, b: u32, c: u32 }
 
 filter foo() {
 	let a = Foo { 

--- a/tests/scripts/type_errors/overriding_builtin.roto
+++ b/tests/scripts/type_errors/overriding_builtin.roto
@@ -1,3 +1,3 @@
-type u32 { b: u32 }
+struct u32 { b: u32 }
 
 fn foo() {}

--- a/tests/scripts/type_errors/types_with_the_same_name.roto
+++ b/tests/scripts/type_errors/types_with_the_same_name.roto
@@ -1,4 +1,4 @@
-type Foo { a: u32 }
-type Foo { b: u32 }
+struct Foo { a: u32 }
+struct Foo { b: u32 }
 
 fn foo() {}

--- a/tests/snapshots/snapshot__type_errors@duplicate_fields.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@duplicate_fields.roto.snap
@@ -4,11 +4,11 @@ expression: string
 input_file: tests/scripts/type_errors/duplicate_fields.roto
 ---
 Error: Type error: field `a` appears multiple times in the same record
-   ╭─[ tests/scripts/type_errors/duplicate_fields.roto:1:12 ]
+   ╭─[ tests/scripts/type_errors/duplicate_fields.roto:1:14 ]
    │
- 1 │ type Foo { a: u32, a: u32 }
-   │            ┬       ┬  
-   │            ╰────────── field `a` declared here
-   │                    │  
-   │                    ╰── field `a` declared here
+ 1 │ struct Foo { a: u32, a: u32 }
+   │              ┬       ┬  
+   │              ╰────────── field `a` declared here
+   │                      │  
+   │                      ╰── field `a` declared here
 ───╯

--- a/tests/snapshots/snapshot__type_errors@overriding_builtin.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@overriding_builtin.roto.snap
@@ -6,7 +6,7 @@ input_file: tests/scripts/type_errors/overriding_builtin.roto
 Error: Type error: cycle detected!
    ╭─[ tests/scripts/type_errors/overriding_builtin.roto:1:1 ]
    │
- 1 │ type u32 { b: u32 }
+ 1 │ struct u32 { b: u32 }
    │ ┬  
    │ ╰── type cycle detected
 ───╯

--- a/tests/snapshots/snapshot__type_errors@types_with_the_same_name.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@types_with_the_same_name.roto.snap
@@ -4,12 +4,12 @@ expression: string
 input_file: tests/scripts/type_errors/types_with_the_same_name.roto
 ---
 Error: Type error: item `Foo` is declared multiple times
-   ╭─[ tests/scripts/type_errors/types_with_the_same_name.roto:2:6 ]
+   ╭─[ tests/scripts/type_errors/types_with_the_same_name.roto:2:8 ]
    │
- 1 │ type Foo { a: u32 }
-   │      ─┬─  
-   │       ╰─── `Foo` previously declared here
- 2 │ type Foo { b: u32 }
-   │      ─┬─  
-   │       ╰─── `Foo` redefined here
+ 1 │ struct Foo { a: u32 }
+   │        ─┬─  
+   │         ╰─── `Foo` previously declared here
+ 2 │ struct Foo { b: u32 }
+   │        ─┬─  
+   │         ╰─── `Foo` redefined here
 ───╯


### PR DESCRIPTION
A little proposal as we add `enum`. Other options include:

 - `record`
 - `class`
 - `data`?

I think I like `struct` best for familiarity.

For an overview of what all sorts of different languages do: https://rosettacode.org/wiki/Compound_data_type