### PR TITLE
Implement type parameters on record types

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -32,6 +32,7 @@ pub struct Params(pub Vec<(Meta<Identifier>, Meta<TypeExpr>)>);
 #[derive(Clone, Debug)]
 pub struct RecordTypeDeclaration {
     pub ident: Meta<Identifier>,
+    pub type_params: Vec<Meta<Identifier>>,
     pub record_type: RecordType,
 }
 

--- a/src/lir/lower.rs
+++ b/src/lir/lower.rs
@@ -555,12 +555,19 @@ impl Lowerer<'_, '_> {
 
         let fields = match res_ty {
             Type::Name(name) => {
-                let TypeDefinition::Record(_, fields) =
+                let TypeDefinition::Record(type_name, fields) =
                     self.ctx.type_info.resolve_type_name(&name)
                 else {
                     ice!()
                 };
+
+                let subs: Vec<_> =
+                    type_name.arguments.iter().zip(&name.arguments).collect();
+
                 fields
+                    .into_iter()
+                    .map(|(ident, ty)| (ident, ty.substitute_many(&subs)))
+                    .collect()
             }
             Type::Record(fields) | Type::RecordVar(_, fields) => fields,
             _ => {

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -1158,3 +1158,54 @@ fn variant_with_never_type_param() {
     );
     typecheck(s).unwrap();
 }
+
+#[test]
+fn generic_record_contains_itself_but_not_quite() {
+    let s = src!(
+        "
+        record Foo[T] {
+            x: Foo[i32],
+        }
+    "
+    );
+
+    typecheck(s).expect_err("type cycle!");
+}
+
+#[test]
+fn assign_generic_to_another() {
+    let s = src!(
+        "
+        record Foo[T] {
+            x: T,
+        }
+
+        fn main() {
+            let x = Foo { x: 10 };
+            let y: Foo[u64] = Foo { x: 20 };
+            y = x;
+        }
+    "
+    );
+
+    typecheck(s).unwrap();
+}
+
+#[test]
+fn assign_generic_to_another_type() {
+    let s = src!(
+        "
+        record Foo[T] {
+            x: T,
+        }
+
+        fn main() {
+            let x: Foo[i32] = Foo { x: 10 };
+            let y: Foo[u64] = Foo { x: 20 };
+            y = x;
+        }
+    "
+    );
+
+    typecheck(s).unwrap_err();
+}

--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -239,6 +239,27 @@ impl TypeDefinition {
         }
         Some(new_variants)
     }
+
+    pub fn record_fields(
+        &self,
+        type_args: &[Type],
+    ) -> Option<Vec<(Meta<Identifier>, Type)>> {
+        let TypeDefinition::Record(type_name, fields) = self else {
+            return None;
+        };
+
+        assert_eq!(type_name.arguments.len(), type_args.len());
+
+        let subs: Vec<_> =
+            type_name.arguments.iter().zip(type_args).collect();
+
+        Some(
+            fields
+                .iter()
+                .map(|(ident, ty)| (ident.clone(), ty.substitute_many(&subs)))
+                .collect(),
+        )
+    }
 }
 
 impl EnumVariant {

--- a/tests/snapshots/snapshot__type_errors@record_literal_on_non_record.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@record_literal_on_non_record.roto.snap
@@ -3,10 +3,10 @@ source: tests/snapshot.rs
 expression: string
 input_file: tests/scripts/type_errors/record_literal_on_non_record.roto
 ---
-Error: Type error: Expected a named record type, but found `String`
+Error: Type error: Expected a record type, but found `String`
    ╭─[ tests/scripts/type_errors/record_literal_on_non_record.roto:2:5 ]
    │
  2 │     String { a: 8 };
    │     ───┬──  
-   │        ╰──── not a named record type
+   │        ╰──── not a record type
 ───╯


### PR DESCRIPTION
Closes https://github.com/NLnetLabs/roto/issues/189

Allows type parameters on `record` types, just like we have on `variant` types.

```roto
record Foo[T] {
    y: T,
}
```