### PR TITLE
Expose RotoFunc trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use cli::cli;
 #[cfg(test)]
 pub(crate) use pipeline::{source_file, src};
 
-pub use codegen::TypedFunc;
+pub use codegen::{TypedFunc, check::RotoFunc};
 pub use file_tree::{FileSpec, FileTree, SourceFile};
 pub(crate) use pipeline::RotoError;
 pub use pipeline::{Package, RotoReport};


### PR DESCRIPTION
This is necessary for building APIs on top of Roto that are generic over the type of function. I realized this while writing some benchmarks.