### PR TITLE
Print type vars for type errors

### DIFF
--- a/src/typechecker/types.rs
+++ b/src/typechecker/types.rs
@@ -348,7 +348,7 @@ impl TypeDisplay for Type {
 
         let ty = type_info.resolve_ref(self);
         match ty {
-            Type::Var(_) => write!(f, "_"),
+            Type::Var(x) => write!(f, "@{x}"),
             Type::ExplicitVar(s) => write!(f, "{s}"),
             Type::IntVar(_, MustBeSigned::Yes) => {
                 write!(f, "{{signed integer}}")

--- a/tests/snapshots/snapshot__type_errors@accept_in_function.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@accept_in_function.roto.snap
@@ -8,5 +8,5 @@ Error: Type error: mismatched types
    │
  2 │     accept
    │     ───┬──  
-   │        ╰──── expected `bool`, found `Verdict[_, _]`
+   │        ╰──── expected `bool`, found `Verdict[@0, @1]`
 ───╯

--- a/tests/snapshots/snapshot__type_errors@missing_accept_or_reject.roto.snap
+++ b/tests/snapshots/snapshot__type_errors@missing_accept_or_reject.roto.snap
@@ -8,5 +8,5 @@ Error: Type error: mismatched types
    │
  2 │     if 2 == 4 { reject }
    │     ──────────┬─────────  
-   │               ╰─────────── expected `Verdict[_, _]`, found `()`
+   │               ╰─────────── expected `Verdict[@0, @1]`, found `()`
 ───╯


### PR DESCRIPTION
This makes debugging type errors a bit easier.