### PR TITLE
docs: mention zed syntax highlighting

### DIFF
--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -18,6 +18,10 @@ The standalone compiler can be installed using cargo:
 Editor support
 --------------
 
+Here is a list of known third party extensions for adding Roto highlighting to editors:
+
+- `Zed <https://zed.dev/extensions/roto>`__
+
 A tree-sitter grammar for Roto is available in the `tree-sitter-roto repository
 <https://github.com/NLnetLabs/tree-sitter-roto>`__. If your editor supports tree-sitter
 you can install it from that repository.


### PR DESCRIPTION
Added a comment to mention the Zed extension.

Render:

<img width="723" height="486" alt="image" src="https://github.com/user-attachments/assets/52ed3656-ba7f-488c-8bc2-0ec91c7f5b61" />
