### PR TITLE
Ensure that multiple files from the source_file! macro don't override each other

### DIFF
--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -26,6 +26,14 @@ pub struct SourceFile {
 }
 
 impl SourceFile {
+    pub fn name(&self) -> String {
+        if self.location_offset > 0 {
+            format!("{}@{}", self.name, self.location_offset)
+        } else {
+            self.name.clone()
+        }
+    }
+
     pub fn read(path: &Path) -> Result<Self, RotoReport> {
         Self::read_internal(path).map_err(|e| read_error(path, e))
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -99,7 +99,7 @@ impl RotoReport {
             .iter()
             .map(|s| {
                 (
-                    s.name.clone(),
+                    s.name(),
                     ariadne::Source::from(s.contents.clone())
                         .with_display_line_offset(s.location_offset),
                 )
@@ -212,7 +212,7 @@ impl std::fmt::Debug for RotoReport {
 
 impl RotoReport {
     fn filename(&self, s: Span) -> String {
-        self.files[s.file].name.clone()
+        self.files[s.file].name()
     }
 }
 


### PR DESCRIPTION
ariadne requires unique names for all files. We were silently overridding files with the same name. This would lead to missing error messages.

Found in https://github.com/NLnetLabs/roto/pull/325