### PR TITLE
Add pratt-like precedence parsing

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -304,10 +304,6 @@ pub enum BinOp {
     Gt,
     /// Greater than or equal (`>=`)
     Ge,
-    /// In
-    In,
-    /// Not in
-    NotIn,
     /// Addition (`+`)
     Add,
     /// Subtraction (`-`)
@@ -332,12 +328,10 @@ impl std::fmt::Display for BinOp {
                 Self::Le => "<",
                 Self::Gt => ">=",
                 Self::Ge => "<",
-                Self::In => "in",
                 Self::Add => "+",
                 Self::Sub => "-",
                 Self::Mul => "*",
                 Self::Div => "/",
-                Self::NotIn => "not in",
             }
         )
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -20,6 +20,7 @@ mod error;
 mod expr;
 mod filter_map;
 pub mod meta;
+mod precedence;
 mod signature;
 pub mod token;
 

--- a/src/parser/precedence.rs
+++ b/src/parser/precedence.rs
@@ -1,0 +1,117 @@
+//! Precedence and associativity of operators in Roto
+//!
+//! This is based on work by Jana Dönszelmann, with explicit permission to use,
+//! modify and distribute it under the BSD-3-Clause license.
+
+use crate::ast::BinOp;
+use std::cmp::Ordering;
+
+/// Precedence of binary operators
+///
+/// The order of the variants of this enum is significant, because it defines
+/// derived implementation of `PartialOrd`/`Ord`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Precedence {
+    /// The precedence of logical disjunction and conjunction.
+    Logical,
+
+    /// The precedence of comparison operators.
+    Comparison,
+
+    /// The precedence of addition and subtraction.
+    AddSub,
+
+    /// The precedence of multiplication and division.
+    MulDiv,
+}
+
+/// Associativity of binary operator.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Associativity {
+    /// Left associativity.
+    ///
+    /// `<x> o <y> o <z>` is parsed as `(<x> o <y>) o <z>`.
+    Left,
+
+    /// Right associativity.
+    ///
+    /// `<x> o <y> o <z>` is parsed as `<x> o (<y> o <z>)`.
+    Right,
+
+    /// Incompatible operators
+    Not,
+}
+
+impl BinOp {
+    fn precedence(&self) -> Precedence {
+        match self {
+            Self::Or | Self::And => Precedence::Logical,
+            Self::Eq
+            | Self::Ne
+            | Self::Lt
+            | Self::Le
+            | Self::Gt
+            | Self::Ge => Precedence::Comparison,
+            Self::Mul | Self::Div => Precedence::MulDiv,
+            Self::Add | Self::Sub => Precedence::AddSub,
+        }
+    }
+
+    fn associativity(&self) -> Associativity {
+        match self.precedence() {
+            Precedence::AddSub | Precedence::MulDiv | Precedence::Logical => {
+                Associativity::Left
+            }
+            Precedence::Comparison => Associativity::Not,
+        }
+    }
+
+    /// Get the relative associativity between a pair of operators.
+    ///
+    /// If we have two operators in sequence, we need to know which one of the
+    /// two binds stronger. That's what this function returns.
+    ///
+    /// For example:
+    ///
+    ///  - `a + b + c` is left associative: `(a + b) + c`
+    ///  - `a * b + c` is left associative: `(a * b) + c`
+    ///  - `a + b * c` is right associative: `a + (b * c)`
+    ///
+    pub fn relative_associativity(&self, other: &Self) -> Associativity {
+        // Special case: we don't allow mixing `||` and `&&`.
+        if let (BinOp::Or, BinOp::And) | (BinOp::And, BinOp::Or) =
+            (self, other)
+        {
+            return Associativity::Not;
+        }
+
+        match self.precedence().cmp(&other.precedence()) {
+            Ordering::Less => Associativity::Right,
+            Ordering::Greater => Associativity::Left,
+            Ordering::Equal => self.associativity(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ast::BinOp, parser::precedence::Associativity};
+
+    fn f(a: BinOp, b: BinOp) -> Associativity {
+        a.relative_associativity(&b)
+    }
+
+    #[test]
+    fn assoc() {
+        use Associativity::*;
+        use BinOp::*;
+
+        assert_eq!(f(Add, Add), Left);
+        assert_eq!(f(Mul, Add), Left);
+        assert_eq!(f(Add, Mul), Right);
+        assert_eq!(f(And, Or), Not);
+        assert_eq!(f(And, And), Left);
+        assert_eq!(f(Or, Or), Left);
+        assert_eq!(f(Eq, Eq), Not);
+    }
+}

--- a/src/typechecker/expr.rs
+++ b/src/typechecker/expr.rs
@@ -930,18 +930,6 @@ impl TypeChecker {
                     Err(self.error_expected_numeric_value(left, &operand_ty))
                 }
             }
-            In | NotIn => {
-                self.unify(&ctx.expected_type, &Type::bool(), span, None)?;
-
-                let ty = self.fresh_var();
-
-                let mut diverges = false;
-                diverges |= self.expr(scope, &ctx.with_type(&ty), left)?;
-                diverges |=
-                    self.expr(scope, &ctx.with_type(Type::list(ty)), right)?;
-
-                Ok(diverges)
-            }
         }
     }
 

--- a/tests/snapshots/snapshot__parse_errors@logical_chain.roto.snap
+++ b/tests/snapshots/snapshot__parse_errors@logical_chain.roto.snap
@@ -9,4 +9,6 @@ Error: Parse error: `||` cannot be chained with `&&`
  2 │     true && false || true && false;
    │                   ─┬  
    │                    ╰── cannot be chained with `&&`
+   │ 
+   │ Note: Try to disambiguate the expression with parentheses.
 ───╯


### PR DESCRIPTION
Closes #321.

This is mostly a refactor, but there are some slight differences. Most notably, comparison operators cannot be chained anymore, just like in Rust.

Additionally, all the operators are now left associative instead of right associative, matching many other languages. This shouldn't normally make much of a difference, but in some edge cases (for example with floats) it matters.

The behaviour that `&&` is incompatible with `||` is preserved.

I removed `in` and `not in` from the code right now, which wasn't properly implemented anyway.

Based on work by @jdonszelmann. 